### PR TITLE
ci: cache RocksDB build and update Go/golangci-lint versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.7'
+          go-version: '1.25'
       - id: changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
@@ -34,34 +34,31 @@ jobs:
             *.sum
       - name: install rocksDB dependencies
         run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            sudo apt-get update
-            sudo apt-get install -y build-essential libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev libzstd-dev cmake
-          else
-            brew install snappy zlib bzip2 gflags
-          fi
-      - name: debug
-        run: |
-          find /usr/local -xdev -name "*ztd*"
+          sudo apt-get update
+          sudo apt-get install -y build-essential libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev libzstd-dev cmake
+      - name: cache rocksdb
+        id: cache-rocksdb
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/rocksdb-install
+          key: rocksdb-v10.9.1-${{ runner.os }}-${{ runner.arch }}
       - name: build and install rocksdb
+        if: steps.cache-rocksdb.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/facebook/rocksdb.git
           cd rocksdb
           git checkout v10.9.1
           mkdir build && cd build
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_SNAPPY=ON -DWITH_LZ4=ON -DWITH_ZLIB=ON -DWITH_ZSTD=ON \
-              -DCMAKE_CXX_FLAGS="-Wno-error=unused-but-set-variable"
-            sudo make -j$(nproc)
-            sudo make install
-          else
-            export PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_SNAPPY=ON -DWITH_LZ4=ON -DWITH_ZLIB=ON -DWITH_ZSTD=ON \
-              -DCMAKE_CXX_FLAGS="-faligned-allocation -Wno-error=unused-but-set-variable" -DCMAKE_PREFIX_PATH=/opt/homebrew \
-              -DCMAKE_EXE_LINKER_FLAGS="-L$(brew --prefix zstd)/lib"
-            sudo make -j$(sysctl -n hw.ncpu)
-            sudo make install
-          fi
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DROCKSDB_BUILD_SHARED=OFF \
+            -DWITH_SNAPPY=ON -DWITH_LZ4=ON -DWITH_ZLIB=ON -DWITH_ZSTD=ON \
+            -DCMAKE_CXX_FLAGS="-Wno-error=unused-but-set-variable" \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/rocksdb-install
+          make -j$(nproc)
+          make install
+      - name: configure CGO for rocksdb
+        run: |
+          echo "CGO_CFLAGS=-I${{ github.workspace }}/rocksdb-install/include" >> $GITHUB_ENV
+          echo "CGO_LDFLAGS=-L${{ github.workspace }}/rocksdb-install/lib" >> $GITHUB_ENV
       - name: test & coverage report creation
         run: |
           make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get install -y build-essential libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev libzstd-dev cmake
       - name: cache rocksdb
         id: cache-rocksdb
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ github.workspace }}/rocksdb-install
           key: rocksdb-v10.9.1-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
           brew install snappy zlib bzip2 gflags
       - name: cache rocksdb
         id: cache-rocksdb
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ github.workspace }}/rocksdb-install
           key: rocksdb-v10.9.1-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.7'
+          go-version: '1.25'
       - id: changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
@@ -33,20 +33,34 @@ jobs:
             *.sum
       - name: install golangci-lint
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
       - name: install rocksDB dependencies
         run: |
           brew install snappy zlib bzip2 gflags
+      - name: cache rocksdb
+        id: cache-rocksdb
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/rocksdb-install
+          key: rocksdb-v10.9.1-${{ runner.os }}-${{ runner.arch }}
       - name: build and install rocksdb
+        if: steps.cache-rocksdb.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/facebook/rocksdb.git
           cd rocksdb
           git checkout v10.9.1
           mkdir build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_SNAPPY=ON -DWITH_LZ4=ON -DWITH_ZLIB=ON -DWITH_ZSTD=ON \
-            -DCMAKE_CXX_FLAGS="-faligned-allocation -Wno-error=unused-but-set-variable"
-          sudo make -j4
-          sudo make install
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DROCKSDB_BUILD_SHARED=OFF \
+            -DWITH_SNAPPY=ON -DWITH_LZ4=ON -DWITH_ZLIB=ON -DWITH_ZSTD=ON \
+            -DCMAKE_CXX_FLAGS="-faligned-allocation -Wno-error=unused-but-set-variable" \
+            -DCMAKE_PREFIX_PATH=$(brew --prefix) \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/rocksdb-install
+          make -j$(sysctl -n hw.ncpu)
+          make install
+      - name: configure CGO for rocksdb
+        run: |
+          echo "CGO_CFLAGS=-I${{ github.workspace }}/rocksdb-install/include" >> $GITHUB_ENV
+          echo "CGO_LDFLAGS=-L${{ github.workspace }}/rocksdb-install/lib" >> $GITHUB_ENV
       - name: run golangci-lint
         run: |
           golangci-lint version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
             *.sum
       - name: install golangci-lint
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+        run: curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
       - name: install rocksDB dependencies
         run: |
           brew install snappy zlib bzip2 gflags


### PR DESCRIPTION
## Summary

- **Cache RocksDB build** across CI runs: installs to `$GITHUB_WORKSPACE/rocksdb-install` (user-owned, no sudo) instead of `/usr/local`, keyed by `rocksdb-v10.9.1-<OS>-<arch>`. The "build and install rocksdb" step is skipped on cache hit; CGO env vars (`CGO_CFLAGS`, `CGO_LDFLAGS`) are set unconditionally so Go finds headers and the static library on both fresh builds and cache restores.
- **Static library only** (`ROCKSDB_BUILD_SHARED=OFF`): avoids shared-lib rpath issues when installing to a non-system prefix.
- **Go 1.22.7 → 1.25 / 1.23.7 → 1.25**: `store/go.mod` requires go 1.25.9 (from cosmos-sdk); CI was failing with GOTOOLCHAIN mismatch.
- **golangci-lint v2.1.6 → v2.12.2**: v2.1.6 was built with go 1.24.2 and refused to lint code targeting go 1.25.9 ("go language version lower than targeted"). v2.12.2 is built with go 1.25.0.
- Removed dead macOS branches from `build.yml` (matrix only runs `ubuntu-latest`) and the temporary `debug` step.
