### PR TITLE
fix(memiavl): abort Commit on async wal write error instead of deadlocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#75](https://github.com/crypto-org-chain/cronos-store/pull/75) fix(memiavl): abort `Commit` on an async WAL write error instead of deadlocking on the `walChan` send under `db.mtx`; also break the snapshot catch-up loop and free the completed snapshot tree when the writer dies.
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -637,8 +637,10 @@ func (db *DB) Commit() (int64, error) {
 		return 0, errReadOnly
 	}
 
-	if db.walErr != nil {
-		return 0, db.walErr
+	// fail fast if the async writer already died, before SaveVersion advances
+	// the in-memory tree past the WAL.
+	if err := db.checkAsyncCommit(); err != nil {
+		return 0, err
 	}
 
 	v, err := db.MultiTree.SaveVersion(true)
@@ -662,7 +664,7 @@ func (db *DB) Commit() (int64, error) {
 				if e := db.latchWalErr(err); e != nil {
 					return 0, e
 				}
-				db.walErr = errors.New("async wal writing goroutine exited unexpectedly")
+				db.walErr = errors.New("async wal writing goroutine quit unexpectedly")
 				return 0, db.walErr
 			}
 		} else {
@@ -746,7 +748,7 @@ func (db *DB) WaitAsyncCommit() error {
 
 func (db *DB) waitAsyncCommit() error {
 	if db.walChan == nil {
-		return nil
+		return db.walErr
 	}
 
 	close(db.walChan)
@@ -754,7 +756,10 @@ func (db *DB) waitAsyncCommit() error {
 
 	db.walChan = nil
 	db.walQuit = nil
-	return err
+	if err != nil {
+		return db.latchWalErr(err)
+	}
+	return db.walErr
 }
 
 func (db *DB) Copy() *DB {

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -536,11 +536,11 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 		// in real world, block execution should be slower than wal writing, so this should not block for long.
 		for {
 			if err := db.checkAsyncCommit(); err != nil {
-				return err
+				return errors.Join(err, result.mtree.Close())
 			}
 			committedVersion, err := db.CommittedVersion()
 			if err != nil {
-				return fmt.Errorf("get wal version failed: %w", err)
+				return errors.Join(fmt.Errorf("get wal version failed: %w", err), result.mtree.Close())
 			}
 			if db.lastCommitInfo.Version == committedVersion {
 				break
@@ -550,10 +550,10 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 
 		// catchup the remaining wal
 		if err := result.mtree.CatchupWAL(db.wal, 0); err != nil {
-			return fmt.Errorf("catchup failed: %w", err)
+			return errors.Join(fmt.Errorf("catchup failed: %w", err), result.mtree.Close())
 		}
 
-		// do the switch
+		// do the switch. reloadMultiTree closes result.mtree itself on failure.
 		if err := db.reloadMultiTree(result.mtree); err != nil {
 			return fmt.Errorf("switch multitree failed: %w", err)
 		}

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -662,8 +662,7 @@ func (db *DB) Commit() (int64, error) {
 			select {
 			case db.walChan <- &entry:
 			case err := <-db.walQuit:
-				_ = db.latchWalErr(err)
-				if db.walErr == nil {
+				if db.walErr = db.latchWalErr(err); db.walErr == nil {
 					db.walErr = errors.New("async wal writing goroutine quit unexpectedly")
 				}
 				return 0, db.walErr

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -553,7 +553,7 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 			return errors.Join(fmt.Errorf("catchup failed: %w", err), result.mtree.Close())
 		}
 
-		// do the switch. reloadMultiTree closes result.mtree itself on failure.
+		// do the switch
 		if err := db.reloadMultiTree(result.mtree); err != nil {
 			return fmt.Errorf("switch multitree failed: %w", err)
 		}
@@ -662,10 +662,10 @@ func (db *DB) Commit() (int64, error) {
 			select {
 			case db.walChan <- &entry:
 			case err := <-db.walQuit:
-				if e := db.latchWalErr(err); e != nil {
-					return 0, e
+				_ = db.latchWalErr(err)
+				if db.walErr == nil {
+					db.walErr = errors.New("async wal writing goroutine quit unexpectedly")
 				}
-				db.walErr = errors.New("async wal writing goroutine quit unexpectedly")
 				return 0, db.walErr
 			}
 		} else {
@@ -757,10 +757,7 @@ func (db *DB) waitAsyncCommit() error {
 
 	db.walChan = nil
 	db.walQuit = nil
-	if err != nil {
-		return db.latchWalErr(err)
-	}
-	return db.walErr
+	return db.latchWalErr(err)
 }
 
 func (db *DB) Copy() *DB {

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -637,8 +637,6 @@ func (db *DB) Commit() (int64, error) {
 		return 0, errReadOnly
 	}
 
-	// fail fast if the async writer already died, before SaveVersion advances
-	// the in-memory tree past the WAL.
 	if err := db.checkAsyncCommit(); err != nil {
 		return 0, err
 	}

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -71,6 +71,8 @@ type DB struct {
 	walChanSize int
 	walChan     chan *walEntry
 	walQuit     chan error
+	// latched async wal writer error; once set, every Commit fails with it.
+	walErr error
 
 	// pending changes, will be written into WAL in next Commit call
 	pendingLog              WALEntry
@@ -479,14 +481,25 @@ func (db *DB) checkAsyncTasks() error {
 
 // checkAsyncCommit check the quit signal of async wal writing
 func (db *DB) checkAsyncCommit() error {
+	if db.walErr != nil {
+		return db.walErr
+	}
 	select {
 	case err := <-db.walQuit:
-		// async wal writing failed, we need to abort the state machine
-		return fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", err)
+		return db.latchWalErr(err)
 	default:
 	}
 
 	return nil
+}
+
+// latchWalErr records a non-nil async wal writer error the first time it's seen
+// and returns the latched error. Callers hold db.mtx.
+func (db *DB) latchWalErr(err error) error {
+	if err != nil && db.walErr == nil {
+		db.walErr = fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", err)
+	}
+	return db.walErr
 }
 
 // CommittedVersion returns the latest version written in wal, or snapshot version if wal is empty.
@@ -624,6 +637,10 @@ func (db *DB) Commit() (int64, error) {
 		return 0, errReadOnly
 	}
 
+	if db.walErr != nil {
+		return 0, db.walErr
+	}
+
 	v, err := db.MultiTree.SaveVersion(true)
 	if err != nil {
 		return 0, err
@@ -637,8 +654,17 @@ func (db *DB) Commit() (int64, error) {
 				db.initAsyncCommit()
 			}
 
-			// async wal writing
-			db.walChan <- &entry
+			// watch walQuit so a dead writer surfaces its error instead of
+			// blocking the send forever under db.mtx.
+			select {
+			case db.walChan <- &entry:
+			case err := <-db.walQuit:
+				if e := db.latchWalErr(err); e != nil {
+					return 0, e
+				}
+				db.walErr = errors.New("async wal writing goroutine exited unexpectedly")
+				return 0, db.walErr
+			}
 		} else {
 			lastIndex, err := db.wal.LastIndex()
 			if err != nil {
@@ -671,7 +697,8 @@ func (db *DB) Commit() (int64, error) {
 
 func (db *DB) initAsyncCommit() {
 	walChan := make(chan *walEntry, db.walChanSize)
-	walQuit := make(chan error)
+	// buffered so an erroring writer can exit instead of parking on the send.
+	walQuit := make(chan error, 1)
 
 	go func() {
 		defer close(walQuit)

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -535,6 +535,9 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 		// wait for potential pending wal writings to finish, to make sure we catch up to latest state.
 		// in real world, block execution should be slower than wal writing, so this should not block for long.
 		for {
+			if err := db.checkAsyncCommit(); err != nil {
+				return err
+			}
 			committedVersion, err := db.CommittedVersion()
 			if err != nil {
 				return fmt.Errorf("get wal version failed: %w", err)

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -919,8 +919,6 @@ func TestEarliestVersionUnpruned(t *testing.T) {
 	require.Greater(t, earliest, int64(0), "EarliestVersion must not report height 0 for unpruned store")
 }
 
-// TestCommitAbortsOnAsyncWALWriteError ensures a failed async wal write surfaces
-// as a Commit error instead of deadlocking on the walChan send while holding db.mtx.
 func TestCommitAbortsOnAsyncWALWriteError(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{
 		CreateIfMissing:   true,
@@ -963,8 +961,6 @@ func TestCommitAbortsOnAsyncWALWriteError(t *testing.T) {
 	require.Error(t, cerr, "Commit must stay failed after an async wal error")
 }
 
-// TestCommitAbortsOnAsyncWALWriteErrorBuffered covers the buffered channel case:
-// once the writer dies, no Commit may report success (that would drop a version).
 func TestCommitAbortsOnAsyncWALWriteErrorBuffered(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{
 		CreateIfMissing:   true,
@@ -998,9 +994,6 @@ func TestCommitAbortsOnAsyncWALWriteErrorBuffered(t *testing.T) {
 	require.True(t, sawError, "async wal writer death never surfaced as a Commit error")
 }
 
-// TestSnapshotRewriteWaitAbortsOnAsyncWALError ensures the snapshot-completion
-// WAL catch-up loop bails out when the async wal writer has died, instead of
-// spinning forever because the WAL can never reach lastCommitInfo.Version.
 func TestSnapshotRewriteWaitAbortsOnAsyncWALError(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{
 		CreateIfMissing:   true,

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -998,3 +998,44 @@ func TestCommitAbortsOnAsyncWALWriteErrorBuffered(t *testing.T) {
 	require.True(t, sawError, "async wal writer death never surfaced as a Commit error")
 }
 
+// TestSnapshotRewriteWaitAbortsOnAsyncWALError ensures the snapshot-completion
+// WAL catch-up loop bails out when the async wal writer has died, instead of
+// spinning forever because the WAL can never reach lastCommitInfo.Version.
+func TestSnapshotRewriteWaitAbortsOnAsyncWALError(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: 0,
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "k", "v")))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.WaitAsyncCommit())
+
+	cv, err := db.CommittedVersion()
+	require.NoError(t, err)
+	db.lastCommitInfo.Version = cv + 1
+	db.walErr = errors.New("simulated async wal writer death")
+
+	mtree := db.MultiTree.Copy(0)
+	defer mtree.Close()
+	ch := make(chan snapshotResult, 1)
+	ch <- snapshotResult{mtree: mtree}
+	db.snapshotRewriteChan = ch
+	db.snapshotRewriteCancel = func() {}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- db.checkBackgroundSnapshotRewrite()
+	}()
+	select {
+	case cerr := <-done:
+		require.Error(t, cerr, "snapshot rewrite catch-up must surface the async wal error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("snapshot rewrite catch-up spun forever after async wal writer death")
+	}
+}
+
+

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -1020,7 +1020,6 @@ func TestSnapshotRewriteWaitAbortsOnAsyncWALError(t *testing.T) {
 	db.walErr = errors.New("simulated async wal writer death")
 
 	mtree := db.MultiTree.Copy(0)
-	defer mtree.Close()
 	ch := make(chan snapshotResult, 1)
 	ch <- snapshotResult{mtree: mtree}
 	db.snapshotRewriteChan = ch

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -1036,5 +1036,3 @@ func TestSnapshotRewriteWaitAbortsOnAsyncWALError(t *testing.T) {
 		t.Fatal("snapshot rewrite catch-up spun forever after async wal writer death")
 	}
 }
-
-

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -962,3 +962,39 @@ func TestCommitAbortsOnAsyncWALWriteError(t *testing.T) {
 	_, cerr := commit()
 	require.Error(t, cerr, "Commit must stay failed after an async wal error")
 }
+
+// TestCommitAbortsOnAsyncWALWriteErrorBuffered covers the buffered channel case:
+// once the writer dies, no Commit may report success (that would drop a version).
+func TestCommitAbortsOnAsyncWALWriteErrorBuffered(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: 16,
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	commit := func() (int64, error) {
+		if err := db.ApplyChangeSets(mockNameChangeSet(testStoreName, "k", "v")); err != nil {
+			return 0, err
+		}
+		return db.Commit()
+	}
+
+	_, err = commit()
+	require.NoError(t, err)
+
+	require.NoError(t, db.wal.Close())
+
+	sawError := false
+	for i := 0; i < 20; i++ {
+		_, cerr := commit()
+		if sawError {
+			require.Error(t, cerr, "Commit returned success after a prior async wal failure")
+		} else if cerr != nil {
+			sawError = true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.True(t, sawError, "async wal writer death never surfaced as a Commit error")
+}
+

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -849,3 +849,47 @@ func TestEarliestVersionUnpruned(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, earliest, int64(0), "EarliestVersion must not report height 0 for unpruned store")
 }
+
+// TestCommitAbortsOnAsyncWALWriteError ensures a failed async wal write surfaces
+// as a Commit error instead of deadlocking on the walChan send while holding db.mtx.
+func TestCommitAbortsOnAsyncWALWriteError(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: 0, // unbuffered async writer: the worst case for the deadlock
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	commit := func() (int64, error) {
+		if err := db.ApplyChangeSets(mockNameChangeSet(testStoreName, "k", "v")); err != nil {
+			return 0, err
+		}
+		return db.Commit()
+	}
+
+	// warm up: spin the async writer goroutine with a successful write.
+	_, err = commit()
+	require.NoError(t, err)
+
+	// break the underlying wal so the writer's next write fails.
+	require.NoError(t, db.wal.Close())
+
+	_, _ = commit()
+	time.Sleep(100 * time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		_, cerr := commit()
+		done <- cerr
+	}()
+	select {
+	case cerr := <-done:
+		require.Error(t, cerr, "Commit must surface the async wal write error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Commit deadlocked after async wal writer failure")
+	}
+
+	// the error is latched, so every subsequent commit keeps failing.
+	_, cerr := commit()
+	require.Error(t, cerr, "Commit must stay failed after an async wal error")
+}


### PR DESCRIPTION
## What

Improve async WAL failure handling so memiavl reports the writer error instead
of deadlocking, spinning during snapshot catch-up, or leaking snapshot resources.

## Issue

In async commit mode, the background WAL writer exits after a WAL write
failure and stops receiving entries from `walChan`.

Previously:

- `Commit` could block sending to `walChan` while holding `db.mtx`.
- The WAL writer could block reporting its error through the unbuffered
  `walQuit`.
- Snapshot catch-up could wait forever for a WAL that would never advance.
- A completed snapshot tree could leak its mmap-backed resources when catch-up
  aborted.

## Solution

- Buffer `walQuit` so the WAL writer can report an error and exit.
- Make `Commit` select between sending to `walChan` and receiving from
  `walQuit`.
- Latch the writer error in `db.walErr`.
- Make subsequent `Commit` calls fail fast with the latched error.
- Return the latched error from `Close` and `WaitAsyncCommit`.
- Abort snapshot catch-up when the WAL writer fails.
- Close the completed snapshot tree when catch-up aborts.

## Tests

- `TestCommitAbortsOnAsyncWALWriteError`
- `TestCommitAbortsOnAsyncWALWriteErrorBuffered`
- `TestSnapshotRewriteWaitAbortsOnAsyncWALError`

Validated with `go test -race`.
