### PR TITLE
fix(store): validate memiavl tree membership on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- [#76](https://github.com/crypto-org-chain/cronos-store/pull/76) fix(store): validate that loaded memiavl trees exactly match the mounted IAVL stores on load, rejecting an unexpected/leftover tree that would otherwise become an extra store in the commit info and diverge the app hash.
+- [#76](https://github.com/crypto-org-chain/cronos-store/pull/76) fix(store): validate memiavl tree membership on load.
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#76](https://github.com/crypto-org-chain/cronos-store/pull/76) fix(store): validate that loaded memiavl trees exactly match the mounted IAVL stores on load, rejecting an unexpected/leftover tree that would otherwise become an extra store in the commit info and diverge the app hash.
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -528,6 +528,12 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 	if err != nil {
 		return errors.Wrapf(err, "fail to load memiavl at %s", rs.dir)
 	}
+	dbInstalled := false
+	defer func() {
+		if !dbInstalled {
+			_ = db.Close()
+		}
+	}()
 
 	var treeUpgrades []*memiavl.TreeNameUpgrade
 	if upgrades != nil {
@@ -548,6 +554,10 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 		}
 	}
 
+	if err := validateMemiAVLTreeMembership(db, initialStores); err != nil {
+		return err
+	}
+
 	newStores := make(map[types.StoreKey]types.CommitStore, len(storesKeys))
 	for _, key := range storesKeys {
 		newStores[key], err = rs.loadCommitStoreFromParams(db, key, rs.storesParams[key])
@@ -557,6 +567,7 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 	}
 
 	rs.db = db
+	dbInstalled = true
 	rs.stores = newStores
 	// to keep the root hash compatible with cosmos-sdk 0.46
 	if db.Version() != 0 {
@@ -568,6 +579,33 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 		rs.lastCommitInfo = &types.CommitInfo{}
 	}
 
+	return nil
+}
+
+func validateMemiAVLTreeMembership(db *memiavl.DB, expectedNames []string) error {
+	expected := make(map[string]struct{}, len(expectedNames))
+	for _, name := range expectedNames {
+		expected[name] = struct{}{}
+	}
+
+	unexpected := make([]string, 0)
+	for _, tree := range db.Trees() {
+		if _, ok := expected[tree.Name]; ok {
+			delete(expected, tree.Name)
+			continue
+		}
+		unexpected = append(unexpected, tree.Name)
+	}
+
+	missing := make([]string, 0, len(expected))
+	for name := range expected {
+		missing = append(missing, name)
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 || len(unexpected) > 0 {
+		return fmt.Errorf("memiavl tree membership mismatch: missing=%v unexpected=%v", missing, unexpected)
+	}
 	return nil
 }
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -554,8 +554,10 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 		}
 	}
 
-	if err := validateMemiAVLTreeMembership(db, initialStores); err != nil {
-		return err
+	if version == 0 || upgrades != nil {
+		if err := validateMemiAVLTreeMembership(db, initialStores); err != nil {
+			return err
+		}
 	}
 
 	newStores := make(map[types.StoreKey]types.CommitStore, len(storesKeys))

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -554,6 +554,8 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 		}
 	}
 
+	// Validate latest and post-upgrade membership. Historical loads may
+	// legitimately contain stores that were deleted or renamed later.
 	if version == 0 || upgrades != nil {
 		if err := validateMemiAVLTreeMembership(db, initialStores); err != nil {
 			return err
@@ -603,9 +605,11 @@ func validateMemiAVLTreeMembership(db *memiavl.DB, expectedNames []string) error
 	for name := range expected {
 		missing = append(missing, name)
 	}
-	sort.Strings(missing)
 
 	if len(missing) > 0 || len(unexpected) > 0 {
+		// The map iteration order is undefined, so sort missing for deterministic
+		// error presentation. unexpected follows db.Trees(), which is ordered by name.
+		sort.Strings(missing)
 		return fmt.Errorf("memiavl tree membership mismatch: missing=%v unexpected=%v", missing, unexpected)
 	}
 	return nil

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -556,7 +556,7 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 
 	// Validate latest and post-upgrade membership. Historical loads may
 	// legitimately contain stores that were deleted or renamed later.
-	if version == 0 || upgrades != nil {
+	if version == 0 || len(treeUpgrades) > 0 {
 		if err := validateMemiAVLTreeMembership(db, initialStores); err != nil {
 			return err
 		}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -75,6 +75,31 @@ func TestLoadVersionAllowsHistoricalMemiAVLTreeMembership(t *testing.T) {
 	require.NoError(t, store.Close())
 }
 
+func TestLoadVersionAndUpgradeAllowsHistoricalMemiAVLTreeMembershipWithEmptyUpgrades(t *testing.T) {
+	dir := t.TempDir()
+	db, err := memiavl.Load(dir, memiavl.Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{oldStoreName, testStoreName},
+		AsyncCommitBuffer: -1,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.ApplyUpgrades([]*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
+
+	// A non-nil but empty StoreUpgrades must not force the exact-membership
+	// check used for latest/upgrade loads onto a historical load.
+	require.NoError(t, store.LoadVersionAndUpgrade(1, &types.StoreUpgrades{}))
+	require.NotNil(t, store.db.TreeByName(oldStoreName))
+	require.NoError(t, store.Close())
+}
+
 func TestLoadLatestVersionAndUpgradeValidatesMemiAVLTreeMembership(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -44,6 +44,155 @@ func TestLoadLatestVersionRejectsUnexpectedMemiAVLTree(t *testing.T) {
 	require.ErrorContains(t, err, "unexpected=[orphan]")
 }
 
+func TestLoadVersionAllowsHistoricalMemiAVLTreeMembership(t *testing.T) {
+	dir := t.TempDir()
+	db, err := memiavl.Load(dir, memiavl.Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{"old", "test"},
+		AsyncCommitBuffer: -1,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.ApplyUpgrades([]*memiavl.TreeNameUpgrade{{Name: "old", Delete: true}}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	store.MountStoreWithDB(types.NewKVStoreKey("test"), types.StoreTypeIAVL, nil)
+
+	require.NoError(t, store.LoadVersion(1))
+	require.NotNil(t, store.db.TreeByName("old"))
+	require.NoError(t, store.Close())
+}
+
+func TestLoadLatestVersionAndUpgradeValidatesMemiAVLTreeMembership(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStores []string
+		mountedStores []string
+		upgrades      *types.StoreUpgrades
+		dataStore     string
+		loadedStore   string
+	}{
+		{
+			name:          "add",
+			initialStores: []string{"test"},
+			mountedStores: []string{"added", "test"},
+			upgrades:      &types.StoreUpgrades{Added: []string{"added"}},
+		},
+		{
+			name:          "delete",
+			initialStores: []string{"deleted", "test"},
+			mountedStores: []string{"test"},
+			upgrades:      &types.StoreUpgrades{Deleted: []string{"deleted"}},
+		},
+		{
+			name:          "rename",
+			initialStores: []string{"old", "test"},
+			mountedStores: []string{"new", "test"},
+			upgrades: &types.StoreUpgrades{Renamed: []types.StoreRename{{
+				OldKey: "old",
+				NewKey: "new",
+			}}},
+			dataStore:   "old",
+			loadedStore: "new",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			db, err := memiavl.Load(dir, memiavl.Options{
+				CreateIfMissing:   true,
+				InitialStores:     tc.initialStores,
+				AsyncCommitBuffer: -1,
+			}, TestAppChainID)
+			require.NoError(t, err)
+			if tc.dataStore != "" {
+				require.NoError(t, db.ApplyChangeSet(tc.dataStore, memiavl.ChangeSet{Pairs: []*memiavl.KVPair{{Key: []byte("k"), Value: []byte("v")}}}))
+			}
+			_, err = db.Commit()
+			require.NoError(t, err)
+			require.NoError(t, db.Close())
+
+			store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+			keys := make(map[string]*types.KVStoreKey, len(tc.mountedStores))
+			for _, name := range tc.mountedStores {
+				key := types.NewKVStoreKey(name)
+				keys[name] = key
+				store.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+			}
+
+			require.NoError(t, store.LoadLatestVersionAndUpgrade(tc.upgrades))
+			require.Len(t, store.db.Trees(), len(tc.mountedStores))
+			for _, name := range tc.mountedStores {
+				require.NotNil(t, store.db.TreeByName(name))
+			}
+			if tc.loadedStore != "" {
+				require.Equal(t, []byte("v"), store.GetKVStore(keys[tc.loadedStore]).Get([]byte("k")))
+			}
+			require.NoError(t, store.Close())
+		})
+	}
+}
+
+func TestLoadLatestVersionAndUpgradeRejectsUnexpectedMemiAVLTree(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStores []string
+		mountedStores []string
+		upgrades      *types.StoreUpgrades
+	}{
+		{
+			name:          "add",
+			initialStores: []string{"orphan", "test"},
+			mountedStores: []string{"added", "test"},
+			upgrades:      &types.StoreUpgrades{Added: []string{"added"}},
+		},
+		{
+			name:          "delete",
+			initialStores: []string{"deleted", "orphan", "test"},
+			mountedStores: []string{"test"},
+			upgrades:      &types.StoreUpgrades{Deleted: []string{"deleted"}},
+		},
+		{
+			name:          "rename",
+			initialStores: []string{"old", "orphan", "test"},
+			mountedStores: []string{"new", "test"},
+			upgrades: &types.StoreUpgrades{Renamed: []types.StoreRename{{
+				OldKey: "old",
+				NewKey: "new",
+			}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			db, err := memiavl.Load(dir, memiavl.Options{
+				CreateIfMissing:   true,
+				InitialStores:     tc.initialStores,
+				AsyncCommitBuffer: -1,
+			}, TestAppChainID)
+			require.NoError(t, err)
+			_, err = db.Commit()
+			require.NoError(t, err)
+			require.NoError(t, db.Close())
+
+			store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+			for _, name := range tc.mountedStores {
+				store.MountStoreWithDB(types.NewKVStoreKey(name), types.StoreTypeIAVL, nil)
+			}
+
+			err = store.LoadLatestVersionAndUpgrade(tc.upgrades)
+			require.ErrorContains(t, err, "memiavl tree membership mismatch")
+			require.ErrorContains(t, err, "unexpected=[orphan]")
+		})
+	}
+}
+
 // newTestStore creates a rootmulti Store with one IAVL sub-store ("test") mounted,
 // loaded, and committed numVersions times so that historical queries are possible.
 // The store uses SnapshotInterval=1 so every commit creates a snapshot.

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -17,7 +17,15 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/v2/types"
 )
 
-const TestAppChainID = "test_chain"
+const (
+	TestAppChainID   = "test_chain"
+	testStoreName    = "test"
+	orphanStoreName  = "orphan"
+	oldStoreName     = "old"
+	newStoreName     = "new"
+	addedStoreName   = "added"
+	deletedStoreName = "deleted"
+)
 
 func TestLastCommitID(t *testing.T) {
 	store := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
@@ -28,7 +36,7 @@ func TestLoadLatestVersionRejectsUnexpectedMemiAVLTree(t *testing.T) {
 	dir := t.TempDir()
 	db, err := memiavl.Load(dir, memiavl.Options{
 		CreateIfMissing:   true,
-		InitialStores:     []string{"orphan", "test"},
+		InitialStores:     []string{orphanStoreName, testStoreName},
 		AsyncCommitBuffer: -1,
 	}, TestAppChainID)
 	require.NoError(t, err)
@@ -37,7 +45,7 @@ func TestLoadLatestVersionRejectsUnexpectedMemiAVLTree(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
-	store.MountStoreWithDB(types.NewKVStoreKey("test"), types.StoreTypeIAVL, nil)
+	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
 
 	err = store.LoadLatestVersion()
 	require.ErrorContains(t, err, "memiavl tree membership mismatch")
@@ -48,22 +56,22 @@ func TestLoadVersionAllowsHistoricalMemiAVLTreeMembership(t *testing.T) {
 	dir := t.TempDir()
 	db, err := memiavl.Load(dir, memiavl.Options{
 		CreateIfMissing:   true,
-		InitialStores:     []string{"old", "test"},
+		InitialStores:     []string{oldStoreName, testStoreName},
 		AsyncCommitBuffer: -1,
 	}, TestAppChainID)
 	require.NoError(t, err)
 	_, err = db.Commit()
 	require.NoError(t, err)
-	require.NoError(t, db.ApplyUpgrades([]*memiavl.TreeNameUpgrade{{Name: "old", Delete: true}}))
+	require.NoError(t, db.ApplyUpgrades([]*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}}))
 	_, err = db.Commit()
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 
 	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
-	store.MountStoreWithDB(types.NewKVStoreKey("test"), types.StoreTypeIAVL, nil)
+	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
 
 	require.NoError(t, store.LoadVersion(1))
-	require.NotNil(t, store.db.TreeByName("old"))
+	require.NotNil(t, store.db.TreeByName(oldStoreName))
 	require.NoError(t, store.Close())
 }
 
@@ -78,26 +86,26 @@ func TestLoadLatestVersionAndUpgradeValidatesMemiAVLTreeMembership(t *testing.T)
 	}{
 		{
 			name:          "add",
-			initialStores: []string{"test"},
-			mountedStores: []string{"added", "test"},
-			upgrades:      &types.StoreUpgrades{Added: []string{"added"}},
+			initialStores: []string{testStoreName},
+			mountedStores: []string{addedStoreName, testStoreName},
+			upgrades:      &types.StoreUpgrades{Added: []string{addedStoreName}},
 		},
 		{
 			name:          "delete",
-			initialStores: []string{"deleted", "test"},
-			mountedStores: []string{"test"},
-			upgrades:      &types.StoreUpgrades{Deleted: []string{"deleted"}},
+			initialStores: []string{deletedStoreName, testStoreName},
+			mountedStores: []string{testStoreName},
+			upgrades:      &types.StoreUpgrades{Deleted: []string{deletedStoreName}},
 		},
 		{
 			name:          "rename",
-			initialStores: []string{"old", "test"},
-			mountedStores: []string{"new", "test"},
+			initialStores: []string{oldStoreName, testStoreName},
+			mountedStores: []string{newStoreName, testStoreName},
 			upgrades: &types.StoreUpgrades{Renamed: []types.StoreRename{{
-				OldKey: "old",
-				NewKey: "new",
+				OldKey: oldStoreName,
+				NewKey: newStoreName,
 			}}},
-			dataStore:   "old",
-			loadedStore: "new",
+			dataStore:   oldStoreName,
+			loadedStore: newStoreName,
 		},
 	}
 
@@ -147,23 +155,23 @@ func TestLoadLatestVersionAndUpgradeRejectsUnexpectedMemiAVLTree(t *testing.T) {
 	}{
 		{
 			name:          "add",
-			initialStores: []string{"orphan", "test"},
-			mountedStores: []string{"added", "test"},
-			upgrades:      &types.StoreUpgrades{Added: []string{"added"}},
+			initialStores: []string{orphanStoreName, testStoreName},
+			mountedStores: []string{addedStoreName, testStoreName},
+			upgrades:      &types.StoreUpgrades{Added: []string{addedStoreName}},
 		},
 		{
 			name:          "delete",
-			initialStores: []string{"deleted", "orphan", "test"},
-			mountedStores: []string{"test"},
-			upgrades:      &types.StoreUpgrades{Deleted: []string{"deleted"}},
+			initialStores: []string{deletedStoreName, orphanStoreName, testStoreName},
+			mountedStores: []string{testStoreName},
+			upgrades:      &types.StoreUpgrades{Deleted: []string{deletedStoreName}},
 		},
 		{
 			name:          "rename",
-			initialStores: []string{"old", "orphan", "test"},
-			mountedStores: []string{"new", "test"},
+			initialStores: []string{oldStoreName, orphanStoreName, testStoreName},
+			mountedStores: []string{newStoreName, testStoreName},
 			upgrades: &types.StoreUpgrades{Renamed: []types.StoreRename{{
-				OldKey: "old",
-				NewKey: "new",
+				OldKey: oldStoreName,
+				NewKey: newStoreName,
 			}}},
 		},
 	}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -24,6 +24,26 @@ func TestLastCommitID(t *testing.T) {
 	require.Equal(t, types.CommitID{}, store.LastCommitID())
 }
 
+func TestLoadLatestVersionRejectsUnexpectedMemiAVLTree(t *testing.T) {
+	dir := t.TempDir()
+	db, err := memiavl.Load(dir, memiavl.Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{"orphan", "test"},
+		AsyncCommitBuffer: -1,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	store.MountStoreWithDB(types.NewKVStoreKey("test"), types.StoreTypeIAVL, nil)
+
+	err = store.LoadLatestVersion()
+	require.ErrorContains(t, err, "memiavl tree membership mismatch")
+	require.ErrorContains(t, err, "unexpected=[orphan]")
+}
+
 // newTestStore creates a rootmulti Store with one IAVL sub-store ("test") mounted,
 // loaded, and committed numVersions times so that historical queries are possible.
 // The store uses SnapshotInterval=1 so every commit creates a snapshot.


### PR DESCRIPTION
## What

Validate that loaded memiavl trees exactly match the mounted IAVL stores before
installing the database.

## Issue

When loading `rootmulti.Store`, the code verified that every mounted IAVL store
had a corresponding memiavl tree, but it did not reject additional trees.

An unexpected tree directory in the active memiavl snapshot could therefore be
loaded and included in the next commit info. A node carrying such a tree could
produce a different app hash from a node whose snapshot contained only the
mounted stores, causing app-hash divergence.

Load failures could also leave the newly loaded database open, leaking file
descriptors and mmap-backed resources.

## Solution

- Add `validateMemiAVLTreeMembership` to require exact membership between
  loaded memiavl trees and mounted IAVL stores.
- Report both missing and unexpected tree names in deterministic order.
- Validate latest and post-upgrade membership before installing the loaded
  database.
- Allow historical loads to retain valid historical membership, including
  stores that were deleted or renamed later.
- Close the loaded database if upgrade application, membership validation, or
  store initialization fails before installation.

## Tests

- Reject an unexpected tree when loading the latest version.
- Allow valid historical membership before a store deletion.
- Cover successful add, delete, and rename upgrades.
- Verify that a rename preserves store data.
- Reject unexpected trees after add, delete, and rename upgrades.
