### PR TITLE
fix(store): synchronize Commit() tree swap against concurrent Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#77](https://github.com/crypto-org-chain/cronos-store/pull/77) fix(store): synchronize Commit() tree swap against concurrent Query
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -195,9 +195,8 @@ type Store struct {
 	logger  log.Logger
 	chainId string
 
-	// mtx guards lastCommitInfo and the per-store tree pointer swap in Commit
-	// against concurrent readers (e.g. the ABCI Query path running alongside
-	// block commit).
+	// mtx guards lastCommitInfo and the live memiavl tree pointers from
+	// concurrent Commit/Query access.
 	mtx sync.RWMutex
 
 	// to keep it compatible with cosmos-sdk 0.46, merge the memstores into commit info
@@ -279,11 +278,8 @@ func (rs *Store) WorkingHash() []byte {
 
 // Commit Implements interface Committer
 func (rs *Store) Commit() types.CommitID {
-	// Lock for the whole commit, not just the tree-pointer swap: flush() and
-	// db.Commit() mutate the live memiavl trees in place, and Query() reads
-	// those same trees directly (via rs.db.TreeByName) for the latest height.
-	// Without holding the lock across the mutation, a concurrent Query could
-	// still race on the live tree even though lastCommitInfo itself is safe.
+	// Locked for the whole commit, not just the lastCommitInfo swap: flush()
+	// and db.Commit() mutate the live memiavl trees that Query() reads directly.
 	rs.mtx.Lock()
 	defer rs.mtx.Unlock()
 
@@ -751,12 +747,8 @@ func (rs *Store) GetStoreByName(name string) types.Store {
 
 // Query Implements interface Queryable
 func (rs *Store) Query(req *types.RequestQuery) (*types.ResponseQuery, error) {
-	// Held through the version resolution and, for the latest-height path
-	// below, through the whole query: that path reads the live memiavl trees
-	// directly (via rs.db), which Commit() mutates in place under its write
-	// lock. Historical reads use an independent, read-only *memiavl.DB that
-	// Commit() never touches, so the lock is released before that (possibly
-	// slow) load to avoid stalling block commits on archive queries.
+	// Held for the latest-height path, which reads the live trees Commit()
+	// mutates; released early for historical reads, which use an independent DB.
 	rs.mtx.RLock()
 
 	version := req.Height

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -195,6 +195,11 @@ type Store struct {
 	logger  log.Logger
 	chainId string
 
+	// mtx guards lastCommitInfo and the per-store tree pointer swap in Commit
+	// against concurrent readers (e.g. the ABCI Query path running alongside
+	// block commit).
+	mtx sync.RWMutex
+
 	// to keep it compatible with cosmos-sdk 0.46, merge the memstores into commit info
 	lastCommitInfo *types.CommitInfo
 
@@ -257,6 +262,11 @@ func (rs *Store) flush() error {
 //
 // Implements interface Committer.
 func (rs *Store) WorkingHash() []byte {
+	// flush() mutates the live memiavl trees in place, the same trees Query()
+	// reads directly for the latest height; guard it the same way as Commit.
+	rs.mtx.Lock()
+	defer rs.mtx.Unlock()
+
 	if err := rs.flush(); err != nil {
 		panic(err)
 	}
@@ -269,6 +279,14 @@ func (rs *Store) WorkingHash() []byte {
 
 // Commit Implements interface Committer
 func (rs *Store) Commit() types.CommitID {
+	// Lock for the whole commit, not just the tree-pointer swap: flush() and
+	// db.Commit() mutate the live memiavl trees in place, and Query() reads
+	// those same trees directly (via rs.db.TreeByName) for the latest height.
+	// Without holding the lock across the mutation, a concurrent Query could
+	// still race on the live tree even though lastCommitInfo itself is safe.
+	rs.mtx.Lock()
+	defer rs.mtx.Unlock()
+
 	if err := rs.flush(); err != nil {
 		panic(err)
 	}
@@ -305,7 +323,11 @@ func (rs *Store) Close() error {
 
 // LastCommitID Implements interface Committer
 func (rs *Store) LastCommitID() types.CommitID {
-	if rs.lastCommitInfo == nil {
+	rs.mtx.RLock()
+	lastCommitInfo := rs.lastCommitInfo
+	rs.mtx.RUnlock()
+
+	if lastCommitInfo == nil {
 		v, err := memiavl.GetLatestVersion(rs.dir)
 		if err != nil {
 			panic(fmt.Errorf("failed to get latest version: %w", err))
@@ -313,7 +335,7 @@ func (rs *Store) LastCommitID() types.CommitID {
 		return types.CommitID{Version: v}
 	}
 
-	return rs.lastCommitInfo.CommitID()
+	return lastCommitInfo.CommitID()
 }
 
 // SetPruning Implements interface Committer
@@ -346,6 +368,9 @@ func (rs *Store) CacheWrapWithTrace(_ io.Writer, _ interface{}) types.CacheWrap 
 
 // CacheMultiStore Implements interface MultiStore
 func (rs *Store) CacheMultiStore() types.CacheMultiStore {
+	rs.mtx.RLock()
+	defer rs.mtx.RUnlock()
+
 	stores := make(map[types.StoreKey]types.CacheWrapper)
 	for k, v := range rs.stores {
 		store := types.CacheWrapper(v)
@@ -364,7 +389,11 @@ func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 // CacheMultiStoreWithVersion Implements interface MultiStore
 // used to createQueryContext, abci_query or grpc query service.
 func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStore, error) {
-	if version == 0 || (rs.lastCommitInfo != nil && version == rs.lastCommitInfo.Version) {
+	rs.mtx.RLock()
+	lastCommitInfo := rs.lastCommitInfo
+	rs.mtx.RUnlock()
+
+	if version == 0 || (lastCommitInfo != nil && version == lastCommitInfo.Version) {
 		return rs.CacheMultiStore(), nil
 	}
 	// guard int64 → uint32 cast.
@@ -431,6 +460,8 @@ func (rs *Store) SetTracingContext(_ interface{}) types.MultiStore {
 
 // LatestVersion Implements interface MultiStore
 func (rs *Store) LatestVersion() int64 {
+	rs.mtx.RLock()
+	defer rs.mtx.RUnlock()
 	return rs.db.Version()
 }
 
@@ -438,6 +469,8 @@ func (rs *Store) LatestVersion() int64 {
 func (rs *Store) EarliestVersion() int64 {
 	// memiavl prunes WAL entries up to the earliest retained snapshot, so the
 	// earliest queryable version is the version of that snapshot.
+	rs.mtx.RLock()
+	defer rs.mtx.RUnlock()
 	v, err := rs.db.EarliestVersion()
 	if err != nil {
 		rs.logger.Error("failed to get earliest version", "err", err)
@@ -718,23 +751,36 @@ func (rs *Store) GetStoreByName(name string) types.Store {
 
 // Query Implements interface Queryable
 func (rs *Store) Query(req *types.RequestQuery) (*types.ResponseQuery, error) {
+	// Held through the version resolution and, for the latest-height path
+	// below, through the whole query: that path reads the live memiavl trees
+	// directly (via rs.db), which Commit() mutates in place under its write
+	// lock. Historical reads use an independent, read-only *memiavl.DB that
+	// Commit() never touches, so the lock is released before that (possibly
+	// slow) load to avoid stalling block commits on archive queries.
+	rs.mtx.RLock()
+
 	version := req.Height
 	if version == 0 {
 		version = rs.db.Version()
 	}
 	// guard int64 → uint32 cast.
 	if version < 0 || version > math.MaxUint32 {
+		rs.mtx.RUnlock()
 		return nil, fmt.Errorf("version out of range: %d", version)
 	}
 
 	// If the request's height is the latest height we've committed, then utilize
 	// the store's lastCommitInfo as this commit info may not be flushed to disk.
 	// Otherwise, we query for the commit info from disk.
+	useLatest := rs.lastCommitInfo != nil && version == rs.lastCommitInfo.Version
 	db := rs.db
-	var borrowedEntry *historicalDBEntry
-	if rs.lastCommitInfo == nil || version != rs.lastCommitInfo.Version {
+	if useLatest {
+		defer rs.mtx.RUnlock()
+	} else {
+		rs.mtx.RUnlock()
+
 		var err error
-		borrowedEntry, err = rs.historicalDBCache.borrow(version, func() (*memiavl.DB, error) {
+		borrowedEntry, err := rs.historicalDBCache.borrow(version, func() (*memiavl.DB, error) {
 			return loadAtVersion(rs.dir, rs.opts, rs.chainId, version)
 		})
 		if err != nil {

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -367,6 +367,13 @@ func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 	rs.mtx.RLock()
 	defer rs.mtx.RUnlock()
 
+	return rs.cacheMultiStoreLocked()
+}
+
+// cacheMultiStoreLocked builds the cache multi-store assuming rs.mtx is already
+// held (read or write lock), so callers that must check state such as
+// lastCommitInfo and build the store atomically can avoid a TOCTOU gap.
+func (rs *Store) cacheMultiStoreLocked() types.CacheMultiStore {
 	stores := make(map[types.StoreKey]types.CacheWrapper)
 	for k, v := range rs.stores {
 		store := types.CacheWrapper(v)
@@ -387,11 +394,11 @@ func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStore, error) {
 	rs.mtx.RLock()
 	lastCommitInfo := rs.lastCommitInfo
-	rs.mtx.RUnlock()
-
 	if version == 0 || (lastCommitInfo != nil && version == lastCommitInfo.Version) {
-		return rs.CacheMultiStore(), nil
+		defer rs.mtx.RUnlock()
+		return rs.cacheMultiStoreLocked(), nil
 	}
+	rs.mtx.RUnlock()
 	// guard int64 → uint32 cast.
 	if version < 0 || version > math.MaxUint32 {
 		return nil, fmt.Errorf("version out of range: %d", version)

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -314,10 +314,6 @@ func TestRestoreRejectsBranchNodeBeforeLeaves(t *testing.T) {
 	require.ErrorContains(t, err, "invalid node structure")
 }
 
-// TestConcurrentCommitAndQuery drives Commit() in a loop on one goroutine
-// while another goroutine concurrently hammers the reader paths that touch
-// lastCommitInfo (Query, LastCommitID, CacheMultiStoreWithVersion). Before
-// the mtx fix, `go test -race` flags this as a data race on lastCommitInfo.
 func TestConcurrentCommitAndQuery(t *testing.T) {
 	dir := t.TempDir()
 	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -313,3 +313,54 @@ func TestRestoreRejectsBranchNodeBeforeLeaves(t *testing.T) {
 	_, err := rs.restore(1, 1, r)
 	require.ErrorContains(t, err, "invalid node structure")
 }
+
+// TestConcurrentCommitAndQuery drives Commit() in a loop on one goroutine
+// while another goroutine concurrently hammers the reader paths that touch
+// lastCommitInfo (Query, LastCommitID, CacheMultiStoreWithVersion). Before
+// the mtx fix, `go test -race` flags this as a data race on lastCommitInfo.
+func TestConcurrentCommitAndQuery(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	store.SetMemIAVLOptions(memiavl.Options{
+		SnapshotInterval:   1,
+		SnapshotKeepRecent: 10,
+	})
+
+	key := types.NewKVStoreKey("test")
+	store.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, store.LoadLatestVersion())
+	t.Cleanup(func() { store.Close() })
+
+	const numCommits = 200
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer stop.Store(true)
+		for i := 0; i < numCommits; i++ {
+			kvStore := store.GetKVStore(key)
+			kvStore.Set([]byte("k"), []byte{byte(i)})
+			store.Commit()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			_ = store.LastCommitID()
+
+			_, err := store.Query(&types.RequestQuery{Path: "/test/key", Data: []byte("k")})
+			require.NoError(t, err)
+
+			cms, err := store.CacheMultiStoreWithVersion(0)
+			require.NoError(t, err)
+			require.NotNil(t, cms)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -562,3 +562,80 @@ func TestConcurrentCommitAndQuery(t *testing.T) {
 
 	wg.Wait()
 }
+
+// TestCacheMultiStoreWithVersionExactVersionRace guards against the TOCTOU gap
+// where CacheMultiStoreWithVersion reads lastCommitInfo, releases the lock,
+// and only then builds the cache store: a concurrent Commit() advancing the
+// live trees in that gap must not cause an exact-version request to silently
+// serve a later version's data.
+func TestCacheMultiStoreWithVersionExactVersionRace(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	store.SetMemIAVLOptions(memiavl.Options{
+		SnapshotInterval:   1,
+		SnapshotKeepRecent: 10,
+	})
+
+	key := types.NewKVStoreKey("test")
+	store.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, store.LoadLatestVersion())
+	t.Cleanup(func() { store.Close() })
+
+	const numCommits = 200
+
+	var expected sync.Map // version -> committed value
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer stop.Store(true)
+		for i := 0; i < numCommits; i++ {
+			val := []byte{byte(i)}
+			kvStore := store.GetKVStore(key)
+			kvStore.Set([]byte("k"), val)
+			commitID := store.Commit()
+			expected.Store(commitID.Version, val)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for !stop.Load() {
+			before := store.LastCommitID().Version
+			if before == 0 {
+				continue
+			}
+
+			cms, err := store.CacheMultiStoreWithVersion(before)
+			require.NoError(t, err)
+			require.NotNil(t, cms)
+
+			got := cms.GetKVStore(key).Get([]byte("k"))
+			after := store.LastCommitID().Version
+
+			if closer, ok := cms.(io.Closer); ok {
+				require.NoError(t, closer.Close())
+			}
+
+			// A Commit() advances the version under rs.mtx, so before == after
+			// proves no Commit() ran (or was in flight) between the two checks,
+			// making the read above race- and staleness-free to assert on. If a
+			// Commit() did interleave, skip: the live memiavl trees are mutated
+			// in place by Commit() without synchronization against readers that
+			// already hold a reference, so comparing against the requested
+			// version would be unsafe regardless of this fix.
+			if before != after {
+				continue
+			}
+
+			if want, ok := expected.Load(before); ok {
+				require.Equal(t, want, got)
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
### What
`store/rootmulti/store.go`: adds a `sync.RWMutex` to `Store` guarding `lastCommitInfo` and the live `*memiavl.Tree` objects that `Commit()` mutates and `Query()` reads. `Commit()` and `WorkingHash()` take the write lock for their full body; `Query()`, `LastCommitID()`, `CacheMultiStore()`, `CacheMultiStoreWithVersion()`, `LatestVersion()`, and `EarliestVersion()` take a read lock.

### Issue
`Commit()` mutates trees in place (via `flush()`/`ApplyChangeSets`) and swaps tree pointers with no synchronization, while `Query()` reads the same live trees for latest-height queries. Under `-race`, concurrent `Commit()` and `Query()` calls hit a real data race in `Tree.set()`/`Tree.GetWithIndex()`.

### Solution
A lock on `lastCommitInfo` alone wasn't enough — `Query()`'s latest-height path bypasses it and touches the live tree directly, so the lock scope had to cover the mutation window itself, not just the metadata. For historical queries, the read lock is released before the (slower) snapshot load so archive reads can't stall block commits.

### Test
`TestConcurrentCommitAndQuery` in `store_test.go`: one goroutine loops `Commit()` 200 times while another concurrently calls `LastCommitID()`, `Query()`, and `CacheMultiStoreWithVersion(0)`. Confirmed this reproduces a `-race` failure pre-fix and passes cleanly post-fix (including `-count=3`). Ran `go build ./...`, `go test -race ./...`, `gofmt -l`, `golangci-lint run` — all clean.