### PR TITLE
fix(store): return error for unknown store name in Query instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#78](https://github.com/crypto-org-chain/cronos-store/pull/78) fix(store): return error for unknown store name in Query instead of panicking
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -800,7 +800,7 @@ func (rs *Store) Query(req *types.RequestQuery) (*types.ResponseQuery, error) {
 
 	tree := db.TreeByName(storeName)
 	if tree == nil {
-		return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "no such store: %s", storeName)
+		return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "store %s not present in historical snapshot at this version", storeName)
 	}
 
 	store := types.Queryable(memiavlstore.New(tree, rs.logger))

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -388,9 +388,15 @@ func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStor
 		}
 	}
 
-	// add all the iavl stores at the target version.
+	// add all the iavl stores at the target version. A historical snapshot may
+	// contain trees for stores later deleted/renamed by a StoreUpgrade; skip
+	// those since there's no current StoreKey to expose them under.
 	for _, tree := range db.Trees() {
-		stores[rs.keysByName[tree.Name]] = memiavlstore.New(tree.Tree, rs.logger)
+		key, ok := rs.keysByName[tree.Name]
+		if !ok {
+			continue
+		}
+		stores[key] = memiavlstore.New(tree.Tree, rs.logger)
 	}
 
 	return cachemulti.NewStore(stores, nil, nil, db), nil
@@ -794,12 +800,14 @@ func (rs *Store) Query(req *types.RequestQuery) (*types.ResponseQuery, error) {
 		return nil, err
 	}
 
-	if _, ok := rs.keysByName[storeName]; !ok {
-		return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "no such store: %s", storeName)
-	}
-
+	// db may be a historical snapshot whose store set differs from the
+	// currently-mounted keysByName (e.g. stores deleted or renamed by a
+	// later upgrade), so the snapshot's own tree set is authoritative.
 	tree := db.TreeByName(storeName)
 	if tree == nil {
+		if _, ok := rs.keysByName[storeName]; !ok {
+			return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "no such store: %s", storeName)
+		}
 		return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "store %s not present in historical snapshot at this version", storeName)
 	}
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -750,7 +750,16 @@ func (rs *Store) Query(req *types.RequestQuery) (*types.ResponseQuery, error) {
 		return nil, err
 	}
 
-	store := types.Queryable(memiavlstore.New(db.TreeByName(storeName), rs.logger))
+	if _, ok := rs.keysByName[storeName]; !ok {
+		return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "no such store: %s", storeName)
+	}
+
+	tree := db.TreeByName(storeName)
+	if tree == nil {
+		return nil, errors.Wrapf(sdkerrors.ErrUnknownRequest, "no such store: %s", storeName)
+	}
+
+	store := types.Queryable(memiavlstore.New(tree, rs.logger))
 
 	// trim the path and make the query
 	req.Path = subpath

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -269,8 +269,6 @@ func TestQueryFutureHeight(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestQueryUnknownStore verifies that querying a store name that isn't
-// mounted returns a clean error instead of panicking on a nil tree.
 func TestQueryUnknownStore(t *testing.T) {
 	store, _ := newTestStore(t, 2)
 	t.Cleanup(func() { store.Close() })
@@ -281,8 +279,6 @@ func TestQueryUnknownStore(t *testing.T) {
 	require.Contains(t, err.Error(), "doesnotexist")
 }
 
-// TestQueryEmptyStoreName verifies that a path with no store name segment
-// (e.g. "/" or "//key") is rejected cleanly rather than panicking.
 func TestQueryEmptyStoreName(t *testing.T) {
 	store, _ := newTestStore(t, 2)
 	t.Cleanup(func() { store.Close() })

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -53,20 +53,30 @@ func TestLoadLatestVersionRejectsUnexpectedMemiAVLTree(t *testing.T) {
 	require.ErrorContains(t, err, "unexpected=[orphan]")
 }
 
-func TestLoadVersionAllowsHistoricalMemiAVLTreeMembership(t *testing.T) {
-	dir := t.TempDir()
+// setupOldStoreAtVersion2 creates a memiavl db with oldStoreName holding key
+// "k"->"v" and testStoreName at version 1, then applies upgrades and commits
+// version 2, closing the db afterward.
+func setupOldStoreAtVersion2(t *testing.T, dir string, upgrades []*memiavl.TreeNameUpgrade) {
+	t.Helper()
+
 	db, err := memiavl.Load(dir, memiavl.Options{
 		CreateIfMissing:   true,
 		InitialStores:     []string{oldStoreName, testStoreName},
 		AsyncCommitBuffer: -1,
 	}, TestAppChainID)
 	require.NoError(t, err)
+	require.NoError(t, db.ApplyChangeSet(oldStoreName, memiavl.ChangeSet{Pairs: []*memiavl.KVPair{{Key: []byte("k"), Value: []byte("v")}}}))
 	_, err = db.Commit()
 	require.NoError(t, err)
-	require.NoError(t, db.ApplyUpgrades([]*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}}))
+	require.NoError(t, db.ApplyUpgrades(upgrades))
 	_, err = db.Commit()
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
+}
+
+func TestLoadVersionAllowsHistoricalMemiAVLTreeMembership(t *testing.T) {
+	dir := t.TempDir()
+	setupOldStoreAtVersion2(t, dir, []*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}})
 
 	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
 	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
@@ -78,18 +88,7 @@ func TestLoadVersionAllowsHistoricalMemiAVLTreeMembership(t *testing.T) {
 
 func TestLoadVersionAndUpgradeAllowsHistoricalMemiAVLTreeMembershipWithEmptyUpgrades(t *testing.T) {
 	dir := t.TempDir()
-	db, err := memiavl.Load(dir, memiavl.Options{
-		CreateIfMissing:   true,
-		InitialStores:     []string{oldStoreName, testStoreName},
-		AsyncCommitBuffer: -1,
-	}, TestAppChainID)
-	require.NoError(t, err)
-	_, err = db.Commit()
-	require.NoError(t, err)
-	require.NoError(t, db.ApplyUpgrades([]*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}}))
-	_, err = db.Commit()
-	require.NoError(t, err)
-	require.NoError(t, db.Close())
+	setupOldStoreAtVersion2(t, dir, []*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}})
 
 	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
 	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
@@ -493,6 +492,50 @@ func TestQueryEmptyStoreName(t *testing.T) {
 		require.Nil(t, res, "path %q", path)
 		require.ErrorIs(t, err, sdkerrors.ErrUnknownRequest, "path %q", path)
 	}
+}
+
+func TestQueryHistoricalHeightAllowsDeletedStore(t *testing.T) {
+	dir := t.TempDir()
+	setupOldStoreAtVersion2(t, dir, []*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}})
+
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
+	require.NoError(t, store.LoadLatestVersion())
+	t.Cleanup(func() { store.Close() })
+
+	res, err := store.Query(&types.RequestQuery{Path: "/old/key", Data: []byte("k"), Height: 1})
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), res.Value)
+}
+
+func TestQueryHistoricalHeightAllowsRenamedStore(t *testing.T) {
+	dir := t.TempDir()
+	setupOldStoreAtVersion2(t, dir, []*memiavl.TreeNameUpgrade{{Name: newStoreName, RenameFrom: oldStoreName}})
+
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	store.MountStoreWithDB(types.NewKVStoreKey(newStoreName), types.StoreTypeIAVL, nil)
+	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
+	require.NoError(t, store.LoadLatestVersion())
+	t.Cleanup(func() { store.Close() })
+
+	res, err := store.Query(&types.RequestQuery{Path: "/old/key", Data: []byte("k"), Height: 1})
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), res.Value)
+}
+
+func TestCacheMultiStoreWithVersionHistoricalHeightSkipsDeletedStore(t *testing.T) {
+	dir := t.TempDir()
+	setupOldStoreAtVersion2(t, dir, []*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}})
+
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	testKey := types.NewKVStoreKey(testStoreName)
+	store.MountStoreWithDB(testKey, types.StoreTypeIAVL, nil)
+	require.NoError(t, store.LoadLatestVersion())
+	t.Cleanup(func() { store.Close() })
+
+	cms, err := store.CacheMultiStoreWithVersion(1)
+	require.NoError(t, err)
+	require.NotPanics(t, func() { cms.GetKVStore(testKey) })
 }
 
 func TestRestoreRejectsIAVLNodeBeforeStore(t *testing.T) {

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -15,6 +15,7 @@ import (
 
 	snapshottypes "github.com/cosmos/cosmos-sdk/store/v2/snapshots/types"
 	"github.com/cosmos/cosmos-sdk/store/v2/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const (
@@ -479,6 +480,7 @@ func TestQueryUnknownStore(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, res)
 	require.Contains(t, err.Error(), "doesnotexist")
+	require.ErrorIs(t, err, sdkerrors.ErrUnknownRequest)
 }
 
 func TestQueryEmptyStoreName(t *testing.T) {
@@ -489,6 +491,7 @@ func TestQueryEmptyStoreName(t *testing.T) {
 		res, err := store.Query(&types.RequestQuery{Path: path, Data: []byte("k")})
 		require.Error(t, err, "path %q", path)
 		require.Nil(t, res, "path %q", path)
+		require.ErrorIs(t, err, sdkerrors.ErrUnknownRequest, "path %q", path)
 	}
 }
 

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -269,6 +269,31 @@ func TestQueryFutureHeight(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestQueryUnknownStore verifies that querying a store name that isn't
+// mounted returns a clean error instead of panicking on a nil tree.
+func TestQueryUnknownStore(t *testing.T) {
+	store, _ := newTestStore(t, 2)
+	t.Cleanup(func() { store.Close() })
+
+	res, err := store.Query(&types.RequestQuery{Path: "/doesnotexist/key", Data: []byte("k")})
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.Contains(t, err.Error(), "doesnotexist")
+}
+
+// TestQueryEmptyStoreName verifies that a path with no store name segment
+// (e.g. "/" or "//key") is rejected cleanly rather than panicking.
+func TestQueryEmptyStoreName(t *testing.T) {
+	store, _ := newTestStore(t, 2)
+	t.Cleanup(func() { store.Close() })
+
+	for _, path := range []string{"/", "//key"} {
+		res, err := store.Query(&types.RequestQuery{Path: path, Data: []byte("k")})
+		require.Error(t, err, "path %q", path)
+		require.Nil(t, res, "path %q", path)
+	}
+}
+
 func TestRestoreRejectsIAVLNodeBeforeStore(t *testing.T) {
 	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
 


### PR DESCRIPTION
### What
`store/rootmulti/store.go`: `Query()` now validates `storeName` before building a `memiavlstore.Store` — checks both `rs.keysByName[storeName]` and `db.TreeByName(storeName)` are present, returning an `ErrUnknownRequest`-wrapped error otherwise.

### Issue
`Query()` built a `memiavlstore.New(db.TreeByName(storeName), ...)` without checking the tree exists, causing a nil-pointer panic on an unknown or empty store name. Since store name is attacker/client-controlled query input, this is a remotely triggerable crash.

### Solution
Two distinct guard conditions are needed since historical DBs can have a different mounted-store set than the current mount list.

### Test
`TestQueryUnknownStore`, `TestQueryEmptyStoreName` in `store_test.go`. `go build ./...`, `go test -race ./...`, `gofmt -l`, `golangci-lint run` all clean.