### PR TITLE
fix(memiavl): avoid deadlock when async WAL writer hits an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#79](https://github.com/crypto-org-chain/cronos-store/pull/79) fix(memiavl): avoid deadlock when async WAL writer hits an error
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -26,9 +26,8 @@ const (
 
 var errReadOnly = errors.New("db is read-only")
 
-// errAsyncWalWriterQuit is used when the async wal writer goroutine exits
-// without reporting an error (e.g. its quit channel is observed closed by a
-// second reader after the first already drained the real error).
+// errAsyncWalWriterQuit covers the closed-channel case: a second reader
+// observes walQuit closed after the first already drained the real error.
 var errAsyncWalWriterQuit = errors.New("async wal writing goroutine already quit")
 
 // DB implements DB-like functionalities on top of MultiTree:
@@ -488,7 +487,7 @@ func (db *DB) checkAsyncTasks() error {
 // checkAsyncCommit check the quit signal of async wal writing
 func (db *DB) checkAsyncCommit() error {
 	if db.walWriterErr != nil {
-		// already reported, keep failing fast without touching the channel again
+		// walQuit is already drained; selecting on it again would just hit default.
 		return fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", db.walWriterErr)
 	}
 
@@ -658,9 +657,8 @@ func (db *DB) Commit() (int64, error) {
 				return 0, fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", db.walWriterErr)
 			}
 
-			// async wal writing; race the send against the writer's quit
-			// signal so a dead writer surfaces as an error instead of
-			// blocking forever on walChan (which nobody drains anymore).
+			// race the send against walQuit: a dead writer no longer drains
+			// walChan, so a plain send would block forever.
 			select {
 			case db.walChan <- &entry:
 			case werr, ok := <-db.walQuit:
@@ -702,10 +700,8 @@ func (db *DB) Commit() (int64, error) {
 
 func (db *DB) initAsyncCommit() {
 	walChan := make(chan *walEntry, db.walChanSize)
-	// buffered so the writer goroutine can always report its error and
-	// return, even if nobody has called checkAsyncCommit/Commit yet to
-	// receive it; otherwise the writer would block forever on this send,
-	// never going back to drain walChan, wedging future Commit calls.
+	// buffered so the writer can report its error and exit even if nobody
+	// is reading walQuit yet; otherwise it would block and never drain walChan.
 	walQuit := make(chan error, 1)
 
 	go func() {
@@ -761,9 +757,8 @@ func (db *DB) waitAsyncCommit() error {
 	close(db.walChan)
 	err := <-db.walQuit
 	if err == nil {
-		// the writer may have already reported its error earlier (e.g. via
-		// Commit's send-select or checkAsyncCommit), in which case walQuit
-		// is already drained and closed, and it reads back as nil here.
+		// walQuit may already be drained and closed if the error was caught
+		// earlier by Commit's send-select or checkAsyncCommit.
 		err = db.walWriterErr
 	}
 

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -26,6 +26,11 @@ const (
 
 var errReadOnly = errors.New("db is read-only")
 
+// errAsyncWalWriterQuit is used when the async wal writer goroutine exits
+// without reporting an error (e.g. its quit channel is observed closed by a
+// second reader after the first already drained the real error).
+var errAsyncWalWriterQuit = errors.New("async wal writing goroutine already quit")
+
 // DB implements DB-like functionalities on top of MultiTree:
 // - async snapshot rewriting
 // - Write-ahead-log
@@ -71,6 +76,9 @@ type DB struct {
 	walChanSize int
 	walChan     chan *walEntry
 	walQuit     chan error
+	// cached error once the async wal writer goroutine has quit, so Commit
+	// keeps failing fast instead of enqueueing into a channel nobody drains.
+	walWriterErr error
 
 	// pending changes, will be written into WAL in next Commit call
 	pendingLog              WALEntry
@@ -479,9 +487,18 @@ func (db *DB) checkAsyncTasks() error {
 
 // checkAsyncCommit check the quit signal of async wal writing
 func (db *DB) checkAsyncCommit() error {
+	if db.walWriterErr != nil {
+		// already reported, keep failing fast without touching the channel again
+		return fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", db.walWriterErr)
+	}
+
 	select {
-	case err := <-db.walQuit:
+	case err, ok := <-db.walQuit:
+		if !ok {
+			err = errAsyncWalWriterQuit
+		}
 		// async wal writing failed, we need to abort the state machine
+		db.walWriterErr = err
 		return fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", err)
 	default:
 	}
@@ -637,8 +654,22 @@ func (db *DB) Commit() (int64, error) {
 				db.initAsyncCommit()
 			}
 
-			// async wal writing
-			db.walChan <- &entry
+			if db.walWriterErr != nil {
+				return 0, fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", db.walWriterErr)
+			}
+
+			// async wal writing; race the send against the writer's quit
+			// signal so a dead writer surfaces as an error instead of
+			// blocking forever on walChan (which nobody drains anymore).
+			select {
+			case db.walChan <- &entry:
+			case werr, ok := <-db.walQuit:
+				if !ok {
+					werr = errAsyncWalWriterQuit
+				}
+				db.walWriterErr = werr
+				return 0, fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", werr)
+			}
 		} else {
 			lastIndex, err := db.wal.LastIndex()
 			if err != nil {
@@ -671,7 +702,11 @@ func (db *DB) Commit() (int64, error) {
 
 func (db *DB) initAsyncCommit() {
 	walChan := make(chan *walEntry, db.walChanSize)
-	walQuit := make(chan error)
+	// buffered so the writer goroutine can always report its error and
+	// return, even if nobody has called checkAsyncCommit/Commit yet to
+	// receive it; otherwise the writer would block forever on this send,
+	// never going back to drain walChan, wedging future Commit calls.
+	walQuit := make(chan error, 1)
 
 	go func() {
 		defer close(walQuit)
@@ -707,6 +742,7 @@ func (db *DB) initAsyncCommit() {
 
 	db.walChan = walChan
 	db.walQuit = walQuit
+	db.walWriterErr = nil
 }
 
 // WaitAsyncCommit waits for the completion of async commit
@@ -724,9 +760,16 @@ func (db *DB) waitAsyncCommit() error {
 
 	close(db.walChan)
 	err := <-db.walQuit
+	if err == nil {
+		// the writer may have already reported its error earlier (e.g. via
+		// Commit's send-select or checkAsyncCommit), in which case walQuit
+		// is already drained and closed, and it reads back as nil here.
+		err = db.walWriterErr
+	}
 
 	db.walChan = nil
 	db.walQuit = nil
+	db.walWriterErr = nil
 	return err
 }
 

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -918,3 +918,51 @@ func TestEarliestVersionUnpruned(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, earliest, int64(0), "EarliestVersion must not report height 0 for unpruned store")
 }
+
+// TestAsyncCommitWalWriterErrorDoesNotDeadlock reproduces the scenario where
+// the async wal writer goroutine has already died after reporting an error:
+// walChan has no reader left (as if the writer quit without looping back to
+// drain it) and walQuit already holds the reported error. On the old,
+// unbuffered-walQuit implementation, Commit() would block forever trying to
+// send on walChan since nothing drains it anymore. The fix must make Commit
+// race the send against the writer's quit signal so it returns the error
+// instead of hanging.
+func TestAsyncCommitWalWriterErrorDoesNotDeadlock(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Load(dir, Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: 0,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.wal.Close() })
+
+	require.NoError(t, db.ApplyChangeSet(testStoreName, ChangeSet{
+		Pairs: []*KVPair{{Key: []byte("k"), Value: []byte("v")}},
+	}))
+
+	// Simulate a dead async writer: an unbuffered walChan with nobody left to
+	// drain it, and walQuit already carrying the error the writer reported
+	// right before it returned.
+	simulatedErr := errors.New("simulated async wal write failure")
+	db.walChan = make(chan *walEntry)
+	db.walQuit = make(chan error, 1)
+	db.walQuit <- simulatedErr
+
+	type commitResult struct {
+		err error
+	}
+	done := make(chan commitResult, 1)
+	go func() {
+		_, err := db.Commit()
+		done <- commitResult{err: err}
+	}()
+
+	select {
+	case res := <-done:
+		require.Error(t, res.err)
+		require.ErrorIs(t, res.err, simulatedErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Commit() did not return within bounded time: async wal writer error handling deadlocked")
+	}
+}

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -919,14 +919,6 @@ func TestEarliestVersionUnpruned(t *testing.T) {
 	require.Greater(t, earliest, int64(0), "EarliestVersion must not report height 0 for unpruned store")
 }
 
-// TestAsyncCommitWalWriterErrorDoesNotDeadlock reproduces the scenario where
-// the async wal writer goroutine has already died after reporting an error:
-// walChan has no reader left (as if the writer quit without looping back to
-// drain it) and walQuit already holds the reported error. On the old,
-// unbuffered-walQuit implementation, Commit() would block forever trying to
-// send on walChan since nothing drains it anymore. The fix must make Commit
-// race the send against the writer's quit signal so it returns the error
-// instead of hanging.
 func TestAsyncCommitWalWriterErrorDoesNotDeadlock(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Load(dir, Options{
@@ -941,9 +933,8 @@ func TestAsyncCommitWalWriterErrorDoesNotDeadlock(t *testing.T) {
 		Pairs: []*KVPair{{Key: []byte("k"), Value: []byte("v")}},
 	}))
 
-	// Simulate a dead async writer: an unbuffered walChan with nobody left to
-	// drain it, and walQuit already carrying the error the writer reported
-	// right before it returned.
+	// simulate a dead async writer: unbuffered walChan nobody drains, and
+	// walQuit already holding the error the writer reported before exiting.
 	simulatedErr := errors.New("simulated async wal write failure")
 	db.walChan = make(chan *walEntry)
 	db.walQuit = make(chan error, 1)


### PR DESCRIPTION
### What
`memiavl/db.go`: `walQuit` is now a buffered channel (cap 1). `Commit()`'s WAL enqueue uses `select` to race the send against a writer-quit signal. A new cached `db.walWriterErr` field lets subsequent `Commit()` calls fail fast once the writer's death is observed, instead of touching the channels again. `checkAsyncCommit`/`waitAsyncCommit` updated to match.

### Issue
On a WAL write error, the async writer goroutine blocked forever sending on unbuffered `walQuit` with nobody receiving, so it never returned to drain `walChan` again. The next `Commit()` then blocked forever on `db.walChan <- &entry` while holding `db.mtx`, wedging the whole DB including `Close()`.

### Solution
Buffering `walQuit` lets the writer always report-then-return. The `select` in `Commit()` surfaces a dead writer as a returned error instead of hanging.

### Test
`TestAsyncCommitWalWriterErrorDoesNotDeadlock` deterministically simulates a dead writer and runs `Commit()` with a 5s bounded timeout; times out pre-fix, passes post-fix. `go test -race ./...`, `gofmt -l`, `golangci-lint run` all clean.