### PR TITLE
fix(memiavl): bound the WAL catch-up wait instead of spinning forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#80](https://github.com/crypto-org-chain/cronos-store/pull/80) fix(memiavl): bound the WAL catch-up wait instead of spinning forever
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -23,10 +23,8 @@ const (
 	DefaultSnapshotWriterLimit = 4
 	TmpSuffix                  = "-tmp"
 
-	// walCatchupTimeout bounds how long checkBackgroundSnapshotRewrite waits for
-	// pending wal writes to catch up before giving up. It's held under db.mtx, so
-	// an unbounded wait here would deadlock the whole DB if the wal writer goroutine
-	// died or got stuck.
+	// Held under db.mtx; unbounded here would deadlock the DB if the wal writer
+	// goroutine died or got stuck.
 	walCatchupTimeout      = 5 * time.Second
 	walCatchupPollInterval = time.Millisecond
 )
@@ -508,10 +506,8 @@ func (db *DB) CommittedVersion() (int64, error) {
 	return walVersion(lastIndex, db.initialVersion), nil
 }
 
-// waitCommittedVersion blocks until the wal's committed version reaches targetVersion,
-// or returns an error once timeout elapses. It's used to let in-flight async wal writes
-// catch up before switching to a rewritten snapshot; if the wal writer goroutine died or
-// got stuck, CommittedVersion would never reach targetVersion, so we must not wait forever.
+// waitCommittedVersion polls CommittedVersion until it reaches targetVersion, bounded
+// by timeout so a stuck wal writer can't block the caller forever.
 func (db *DB) waitCommittedVersion(targetVersion int64, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
@@ -549,8 +545,6 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 
 		// wait for potential pending wal writings to finish, to make sure we catch up to latest state.
 		// in real world, block execution should be slower than wal writing, so this should not block for long.
-		// bounded by walCatchupTimeout so a stuck/dead wal writer goroutine can't spin this
-		// forever while holding db.mtx.
 		if err := db.waitCommittedVersion(db.lastCommitInfo.Version, walCatchupTimeout); err != nil {
 			return err
 		}

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -23,8 +23,6 @@ const (
 	DefaultSnapshotWriterLimit = 4
 	TmpSuffix                  = "-tmp"
 
-	// Held under db.mtx; unbounded here would deadlock the DB if the wal writer
-	// goroutine died or got stuck.
 	walCatchupTimeout = 5 * time.Second
 )
 
@@ -505,8 +503,6 @@ func (db *DB) CommittedVersion() (int64, error) {
 	return walVersion(lastIndex, db.initialVersion), nil
 }
 
-// waitCommittedVersion polls CommittedVersion until it reaches targetVersion, bounded
-// by timeout so a stuck wal writer can't block the caller forever.
 func (db *DB) waitCommittedVersion(targetVersion int64, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {
@@ -520,7 +516,7 @@ func (db *DB) waitCommittedVersion(targetVersion int64, timeout time.Duration) e
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timed out waiting for wal to catch up to committed version %d, current: %d", targetVersion, committedVersion)
 		}
-		time.Sleep(time.Microsecond)
+		time.Sleep(time.Nanosecond)
 	}
 }
 

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -516,7 +516,7 @@ func (db *DB) waitCommittedVersion(targetVersion int64, timeout time.Duration) e
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timed out waiting for wal to catch up to committed version %d, current: %d", targetVersion, committedVersion)
 		}
-		time.Sleep(time.Nanosecond)
+		time.Sleep(50 * time.Nanosecond)
 	}
 }
 

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -22,6 +22,13 @@ const (
 	LockFileName               = "LOCK"
 	DefaultSnapshotWriterLimit = 4
 	TmpSuffix                  = "-tmp"
+
+	// walCatchupTimeout bounds how long checkBackgroundSnapshotRewrite waits for
+	// pending wal writes to catch up before giving up. It's held under db.mtx, so
+	// an unbounded wait here would deadlock the whole DB if the wal writer goroutine
+	// died or got stuck.
+	walCatchupTimeout      = 5 * time.Second
+	walCatchupPollInterval = time.Millisecond
 )
 
 var errReadOnly = errors.New("db is read-only")
@@ -501,6 +508,27 @@ func (db *DB) CommittedVersion() (int64, error) {
 	return walVersion(lastIndex, db.initialVersion), nil
 }
 
+// waitCommittedVersion blocks until the wal's committed version reaches targetVersion,
+// or returns an error once timeout elapses. It's used to let in-flight async wal writes
+// catch up before switching to a rewritten snapshot; if the wal writer goroutine died or
+// got stuck, CommittedVersion would never reach targetVersion, so we must not wait forever.
+func (db *DB) waitCommittedVersion(targetVersion int64, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		committedVersion, err := db.CommittedVersion()
+		if err != nil {
+			return fmt.Errorf("get wal version failed: %w", err)
+		}
+		if targetVersion == committedVersion {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for wal to catch up to committed version %d, current: %d", targetVersion, committedVersion)
+		}
+		time.Sleep(walCatchupPollInterval)
+	}
+}
+
 // checkBackgroundSnapshotRewrite check the result of background snapshot rewrite, cleans up the old snapshots and switches to a new multitree
 func (db *DB) checkBackgroundSnapshotRewrite() error {
 	// check the completeness of background snapshot rewriting
@@ -521,15 +549,10 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 
 		// wait for potential pending wal writings to finish, to make sure we catch up to latest state.
 		// in real world, block execution should be slower than wal writing, so this should not block for long.
-		for {
-			committedVersion, err := db.CommittedVersion()
-			if err != nil {
-				return fmt.Errorf("get wal version failed: %w", err)
-			}
-			if db.lastCommitInfo.Version == committedVersion {
-				break
-			}
-			time.Sleep(time.Nanosecond)
+		// bounded by walCatchupTimeout so a stuck/dead wal writer goroutine can't spin this
+		// forever while holding db.mtx.
+		if err := db.waitCommittedVersion(db.lastCommitInfo.Version, walCatchupTimeout); err != nil {
+			return err
 		}
 
 		// catchup the remaining wal

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -515,7 +515,7 @@ func (db *DB) waitCommittedVersion(targetVersion int64, timeout time.Duration) e
 		if err != nil {
 			return fmt.Errorf("get wal version failed: %w", err)
 		}
-		if targetVersion == committedVersion {
+		if committedVersion >= targetVersion {
 			return nil
 		}
 		if time.Now().After(deadline) {

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -24,6 +24,7 @@ const (
 	TmpSuffix                  = "-tmp"
 
 	walCatchupTimeout = 5 * time.Second
+	walPollInterval   = 50 * time.Nanosecond
 )
 
 var errReadOnly = errors.New("db is read-only")
@@ -516,7 +517,7 @@ func (db *DB) waitCommittedVersion(targetVersion int64, timeout time.Duration) e
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timed out waiting for wal to catch up to committed version %d, current: %d", targetVersion, committedVersion)
 		}
-		time.Sleep(50 * time.Nanosecond)
+		time.Sleep(walPollInterval)
 	}
 }
 

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -25,8 +25,7 @@ const (
 
 	// Held under db.mtx; unbounded here would deadlock the DB if the wal writer
 	// goroutine died or got stuck.
-	walCatchupTimeout      = 5 * time.Second
-	walCatchupPollInterval = time.Millisecond
+	walCatchupTimeout = 5 * time.Second
 )
 
 var errReadOnly = errors.New("db is read-only")
@@ -521,7 +520,7 @@ func (db *DB) waitCommittedVersion(targetVersion int64, timeout time.Duration) e
 		if time.Now().After(deadline) {
 			return fmt.Errorf("timed out waiting for wal to catch up to committed version %d, current: %d", targetVersion, committedVersion)
 		}
-		time.Sleep(walCatchupPollInterval)
+		time.Sleep(time.Microsecond)
 	}
 }
 

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -126,10 +126,6 @@ func TestRewriteSnapshotBackground(t *testing.T) {
 	require.Equal(t, 4, len(entries))
 }
 
-// TestWaitCommittedVersionTimesOut guards against the wal catch-up wait in
-// checkBackgroundSnapshotRewrite spinning forever when the wal writer can
-// never reach the target version (e.g. it died or got stuck). It must return
-// an error within the bounded timeout instead of blocking indefinitely.
 func TestWaitCommittedVersionTimesOut(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{
 		CreateIfMissing: true,
@@ -160,9 +156,6 @@ func TestWaitCommittedVersionTimesOut(t *testing.T) {
 	}
 }
 
-// TestWaitCommittedVersionSucceedsWhenCaughtUp verifies the healthy path is
-// unchanged: waiting for a version that's already committed returns immediately
-// without error.
 func TestWaitCommittedVersionSucceedsWhenCaughtUp(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{
 		CreateIfMissing: true,

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -126,6 +126,67 @@ func TestRewriteSnapshotBackground(t *testing.T) {
 	require.Equal(t, 4, len(entries))
 }
 
+// TestWaitCommittedVersionTimesOut guards against the wal catch-up wait in
+// checkBackgroundSnapshotRewrite spinning forever when the wal writer can
+// never reach the target version (e.g. it died or got stuck). It must return
+// an error within the bounded timeout instead of blocking indefinitely.
+func TestWaitCommittedVersionTimesOut(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer db.Close()
+
+	committedVersion, err := db.CommittedVersion()
+	require.NoError(t, err)
+
+	// target a version that the wal will never reach, simulating a stuck/dead wal writer.
+	unreachableTarget := committedVersion + 1000
+
+	const testTimeout = 200 * time.Millisecond
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- db.waitCommittedVersion(unreachableTarget, testTimeout)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "timed out waiting for wal to catch up")
+	case <-time.After(testTimeout * 10):
+		t.Fatal("waitCommittedVersion did not return within the bounded timeout; it is spinning forever")
+	}
+}
+
+// TestWaitCommittedVersionSucceedsWhenCaughtUp verifies the healthy path is
+// unchanged: waiting for a version that's already committed returns immediately
+// without error.
+func TestWaitCommittedVersionSucceedsWhenCaughtUp(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer db.Close()
+
+	committedVersion, err := db.CommittedVersion()
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- db.waitCommittedVersion(committedVersion, 5*time.Second)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitCommittedVersion did not return for an already-caught-up version")
+	}
+}
+
 func TestReloadRetainsSnapshotForCopy(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{
 		CreateIfMissing: true,

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -180,6 +180,42 @@ func TestWaitCommittedVersionSucceedsWhenCaughtUp(t *testing.T) {
 	}
 }
 
+func TestWaitCommittedVersionSucceedsWhenWalAdvancesPastTarget(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "k", "v")))
+	_, err = db.Commit()
+	require.NoError(t, err)
+
+	committedVersion, err := db.CommittedVersion()
+	require.NoError(t, err)
+
+	// target a version the wal has already passed, simulating a concurrent commit
+	// that advanced the wal beyond the target between polls. An exact "==" check would
+	// never match again and spin until timeout; ">=" must succeed immediately.
+	pastTarget := committedVersion - 1
+	require.GreaterOrEqual(t, pastTarget, int64(0))
+
+	const testTimeout = 200 * time.Millisecond
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- db.waitCommittedVersion(pastTarget, testTimeout)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(testTimeout * 10):
+		t.Fatal("waitCommittedVersion did not return promptly when wal already advanced past target")
+	}
+}
+
 func TestReloadRetainsSnapshotForCopy(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{
 		CreateIfMissing: true,


### PR DESCRIPTION
### What
`memiavl/db.go`: `checkBackgroundSnapshotRewrite`'s unbounded busy-wait loop is replaced with `waitCommittedVersion(targetVersion int64, timeout time.Duration) error`, bounded by new constants `walCatchupTimeout` (5s) and `walPollInterval` (50ns).

### Issue
The loop spun with no timeout waiting for the committed version to catch up, so a stuck writer or unreachable target version hung the caller forever.

### Solution
Returns a timeout error instead, propagated through the existing `checkAsyncTasks` → `errors.Join` → `Commit()` chain with no signature changes elsewhere. Confirmed `CommittedVersion()` doesn't re-lock `db.mtx`, so no self-deadlock is introduced by polling it.

### Test
`TestWaitCommittedVersionTimesOut`, `TestWaitCommittedVersionSucceedsWhenCaughtUp`. `go test -race ./...`, `gofmt -l`, `golangci-lint run` all clean.