### PR TITLE
fix(memiavl): return error instead of panicking on empty-tree membership proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#81](https://github.com/crypto-org-chain/cronos-store/pull/81) fix(memiavl): return error instead of panicking on empty-tree membership proof
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/proof.go
+++ b/memiavl/proof.go
@@ -84,6 +84,11 @@ func (t *Tree) VerifyNonMembership(proof *ics23.CommitmentProof, key []byte) boo
 // createExistenceProof will get the proof from the tree and convert the proof into a valid
 // existence proof, if that's what it is.
 func (t *Tree) createExistenceProof(key []byte) (*ics23.ExistenceProof, error) {
+	if t.root == nil {
+		// an empty tree has no keys, so no membership proof can exist for any key.
+		return nil, errors.New("key does not exist")
+	}
+
 	path, node, err := pathToLeaf(t.root, key)
 	return &ics23.ExistenceProof{
 		Key:   node.Key(),

--- a/memiavl/proof.go
+++ b/memiavl/proof.go
@@ -39,6 +39,11 @@ GetNonMembershipProof will produce a CommitmentProof that the given key doesn't 
 If the key exists in the tree, this will return an error.
 */
 func (t *Tree) GetNonMembershipProof(key []byte) (*ics23.CommitmentProof, error) {
+	if t.root == nil {
+		// an empty tree has no keys to anchor a non-existence proof against ics23.
+		return nil, errors.New("cannot create non-existence proof for an empty tree")
+	}
+
 	// idx is one node right of what we want....
 	var err error
 	idx, val := t.GetWithIndex(key)

--- a/memiavl/proof.go
+++ b/memiavl/proof.go
@@ -40,7 +40,6 @@ If the key exists in the tree, this will return an error.
 */
 func (t *Tree) GetNonMembershipProof(key []byte) (*ics23.CommitmentProof, error) {
 	if t.root == nil {
-		// an empty tree has no keys to anchor a non-existence proof against ics23.
 		return nil, errors.New("cannot create non-existence proof for an empty tree")
 	}
 
@@ -90,7 +89,6 @@ func (t *Tree) VerifyNonMembership(proof *ics23.CommitmentProof, key []byte) boo
 // existence proof, if that's what it is.
 func (t *Tree) createExistenceProof(key []byte) (*ics23.ExistenceProof, error) {
 	if t.root == nil {
-		// an empty tree has no keys, so no membership proof can exist for any key.
 		return nil, errors.New("key does not exist")
 	}
 

--- a/memiavl/proof_test.go
+++ b/memiavl/proof_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestProofsEmptyTree(t *testing.T) {
+	tree := New(0)
+
+	proof, err := tree.GetMembershipProof([]byte("hello"))
+	require.Error(t, err)
+	require.Nil(t, proof)
+}
+
 func TestProofs(t *testing.T) {
 	// do a round test for each version in ChangeSets
 	testCases := []struct {

--- a/memiavl/proof_test.go
+++ b/memiavl/proof_test.go
@@ -13,6 +13,10 @@ func TestProofsEmptyTree(t *testing.T) {
 	proof, err := tree.GetMembershipProof([]byte("hello"))
 	require.Error(t, err)
 	require.Nil(t, proof)
+
+	nonExistProof, err := tree.GetNonMembershipProof([]byte("hello"))
+	require.Error(t, err)
+	require.Nil(t, nonExistProof)
 }
 
 func TestProofs(t *testing.T) {


### PR DESCRIPTION
### What
`memiavl/proof.go`:
- `createExistenceProof` checks for a nil root before calling `pathToLeaf`, returning `errors.New("key does not exist")` instead of proceeding.
- `GetNonMembershipProof` checks for a nil root up front, returning an error instead of an unverifiable proof.

### Issue
On an empty tree, `pathToLeaf(t.root, key)` called `node.Height()` on a nil `Node`, panicking. This is reachable via state-sync/proof requests from untrusted peers.

Separately, `GetNonMembershipProof` on an empty tree didn't panic but returned a `NonExistenceProof` with both `Left` and `Right` nil. ics23 rejects that shape during verification ("both left and right proofs missing"), so the proof was silently unverifiable — a caller checking `VerifyNonMembership` would just get `false` with no error and no clear reason why.

### Solution
Matches the existing convention already used elsewhere in the file (`RootHash`, `Get`, `GetWithIndex`) for the same "empty tree" case: fail fast with an error rather than return a value that looks valid but isn't.

### Test
`TestProofsEmptyTree` in `proof_test.go` covers both `GetMembershipProof` and `GetNonMembershipProof` on an empty tree. `go test -race ./...`, `gofmt -l`, `golangci-lint run` all clean.