### PR TITLE
fix(memiavl): close loaded MultiTree when CatchupWAL fails during snapshot rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#82](https://github.com/crypto-org-chain/cronos-store/pull/82) fix(memiavl): close loaded MultiTree when CatchupWAL fails during snapshot rewrite
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -532,7 +532,7 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 			time.Sleep(time.Nanosecond)
 		}
 
-		// on failure, close the tree to release its mmap'd snapshot files before returning.
+		// catchup the remaining wal
 		if err := result.mtree.CatchupWAL(db.wal, 0); err != nil {
 			return errors.Join(fmt.Errorf("final catchup failed: %w", err), result.mtree.Close())
 		}
@@ -873,7 +873,6 @@ func (db *DB) rewriteSnapshotBackground() error {
 
 		// do a best effort catch-up, will do another final catch-up in main thread.
 		if err := mtree.CatchupWAL(wal, 0); err != nil {
-			// close the tree here too, otherwise its mmap'd snapshot files leak.
 			ch <- snapshotResult{err: errors.Join(err, mtree.Close())}
 			return
 		}

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -532,8 +532,7 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 			time.Sleep(time.Nanosecond)
 		}
 
-		// catchup the remaining wal; on failure close the freshly loaded tree to
-		// release its mmap'd snapshot files before propagating the error.
+		// on failure, close the tree to release its mmap'd snapshot files before returning.
 		if err := result.mtree.CatchupWAL(db.wal, 0); err != nil {
 			return errors.Join(fmt.Errorf("catchup failed: %w", err), result.mtree.Close())
 		}
@@ -874,8 +873,7 @@ func (db *DB) rewriteSnapshotBackground() error {
 
 		// do a best effort catch-up, will do another final catch-up in main thread.
 		if err := mtree.CatchupWAL(wal, 0); err != nil {
-			// close the freshly loaded tree to release its mmap'd snapshot files
-			// before propagating the error, otherwise fds/mmaps leak.
+			// close the tree here too, otherwise its mmap'd snapshot files leak.
 			ch <- snapshotResult{err: errors.Join(err, mtree.Close())}
 			return
 		}

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -532,9 +532,10 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 			time.Sleep(time.Nanosecond)
 		}
 
-		// catchup the remaining wal
+		// catchup the remaining wal; on failure close the freshly loaded tree to
+		// release its mmap'd snapshot files before propagating the error.
 		if err := result.mtree.CatchupWAL(db.wal, 0); err != nil {
-			return fmt.Errorf("catchup failed: %w", err)
+			return errors.Join(fmt.Errorf("catchup failed: %w", err), result.mtree.Close())
 		}
 
 		// do the switch
@@ -873,7 +874,9 @@ func (db *DB) rewriteSnapshotBackground() error {
 
 		// do a best effort catch-up, will do another final catch-up in main thread.
 		if err := mtree.CatchupWAL(wal, 0); err != nil {
-			ch <- snapshotResult{err: err}
+			// close the freshly loaded tree to release its mmap'd snapshot files
+			// before propagating the error, otherwise fds/mmaps leak.
+			ch <- snapshotResult{err: errors.Join(err, mtree.Close())}
 			return
 		}
 

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -534,7 +534,7 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 
 		// on failure, close the tree to release its mmap'd snapshot files before returning.
 		if err := result.mtree.CatchupWAL(db.wal, 0); err != nil {
-			return errors.Join(fmt.Errorf("catchup failed: %w", err), result.mtree.Close())
+			return errors.Join(fmt.Errorf("final catchup failed: %w", err), result.mtree.Close())
 		}
 
 		// do the switch

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -560,9 +560,20 @@ func corruptTrailingWALEntry(t *testing.T, db *DB) int64 {
 	require.NoError(t, err)
 
 	corruptIndex := lastIndex + 1
+	// carries an invalid protobuf wire type (field 13, wire type 6, both undefined),
+	// so WALEntry.Unmarshal reliably rejects it as corrupt.
 	require.NoError(t, db.wal.Write(corruptIndex, []byte("not a valid WALEntry")))
 
 	return walVersion(corruptIndex, db.initialVersion)
+}
+
+// injectSnapshotRewriteResult stubs a completed background snapshot rewrite, so
+// callers can drive checkBackgroundSnapshotRewrite without a real goroutine.
+func injectSnapshotRewriteResult(db *DB, mtree *MultiTree) {
+	ch := make(chan snapshotResult, 1)
+	ch <- snapshotResult{mtree: mtree}
+	db.snapshotRewriteChan = ch
+	db.snapshotRewriteCancel = func() {}
 }
 
 func TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure(t *testing.T) {
@@ -589,10 +600,7 @@ func TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure(t *testing.T)
 	mtree, err := LoadMultiTree(currentPath(db.dir), db.zeroCopy, db.cacheSize, db.chainId)
 	require.NoError(t, err)
 
-	ch := make(chan snapshotResult, 1)
-	ch <- snapshotResult{mtree: mtree}
-	db.snapshotRewriteChan = ch
-	db.snapshotRewriteCancel = func() {}
+	injectSnapshotRewriteResult(db, mtree)
 
 	err = db.checkBackgroundSnapshotRewrite()
 	require.Error(t, err, "catchup failure must be propagated")
@@ -624,11 +632,14 @@ func TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure(t *testing.T) {
 	case result := <-db.snapshotRewriteChan:
 		require.Error(t, result.err, "background catchup failure must be reported")
 		require.Nil(t, result.mtree, "no tree handed back on failure, so no way to leak it via the result")
+		db.snapshotRewriteChan = nil
+		db.snapshotRewriteCancel = nil
 	case <-time.After(5 * time.Second):
+		// leave snapshotRewriteChan/Cancel set so the deferred db.Close() still
+		// cancels and drains the goroutine instead of orphaning it.
+		db.snapshotRewriteCancel()
 		t.Fatal("timed out waiting for background snapshot rewrite result: goroutine likely hung")
 	}
-	db.snapshotRewriteChan = nil
-	db.snapshotRewriteCancel = nil
 }
 
 func TestZeroCopy(t *testing.T) {
@@ -1124,11 +1135,7 @@ func TestSnapshotRewriteWaitAbortsOnAsyncWALError(t *testing.T) {
 	db.lastCommitInfo.Version = cv + 1
 	db.walErr = errors.New("simulated async wal writer death")
 
-	mtree := db.MultiTree.Copy(0)
-	ch := make(chan snapshotResult, 1)
-	ch <- snapshotResult{mtree: mtree}
-	db.snapshotRewriteChan = ch
-	db.snapshotRewriteCancel = func() {}
+	injectSnapshotRewriteResult(db, db.MultiTree.Copy(0))
 
 	done := make(chan error, 1)
 	go func() {

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -519,10 +519,8 @@ func TestCatchupWALNegativeEndVersion(t *testing.T) {
 	require.Error(t, db.CatchupWAL(db.wal, -1), "negative endVersion must return an error")
 }
 
-// corruptTrailingWALEntry appends a garbage WAL entry right after the wal's current
-// last index, so any CatchupWAL call that reaches it fails to unmarshal. It returns
-// the version the corrupt entry pretends to be, so callers can keep lastCommitInfo
-// consistent with the wal's reported committed version.
+// corruptTrailingWALEntry returns the version the corrupt entry pretends to be, so
+// callers can keep lastCommitInfo consistent with the wal's reported committed version.
 func corruptTrailingWALEntry(t *testing.T, db *DB) int64 {
 	t.Helper()
 
@@ -535,9 +533,6 @@ func corruptTrailingWALEntry(t *testing.T, db *DB) int64 {
 	return walVersion(corruptIndex, db.initialVersion)
 }
 
-// TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure verifies that when the
-// wal catch-up step in checkBackgroundSnapshotRewrite fails, the freshly loaded MultiTree
-// (which just mmap'd a whole snapshot's worth of files) is closed rather than leaked.
 func TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Load(dir, Options{
@@ -555,9 +550,8 @@ func TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure(t *testing.T)
 	require.NoError(t, db.RewriteSnapshot())
 
 	corruptVersion := corruptTrailingWALEntry(t, db)
-	// bypass the wal-catchup wait loop: we appended the corrupt entry directly to the
-	// wal, not through Commit, so db.lastCommitInfo.Version must be nudged to match the
-	// wal's reported committed version or checkBackgroundSnapshotRewrite would spin forever.
+	// the corrupt entry bypassed Commit, so nudge lastCommitInfo to match the wal's
+	// reported version or checkBackgroundSnapshotRewrite's wait loop spins forever.
 	db.lastCommitInfo.Version = corruptVersion
 
 	mtree, err := LoadMultiTree(currentPath(db.dir), db.zeroCopy, db.cacheSize, db.chainId)
@@ -571,14 +565,10 @@ func TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure(t *testing.T)
 	err = db.checkBackgroundSnapshotRewrite()
 	require.Error(t, err, "catchup failure must be propagated")
 
-	// MultiTree.Close nils out t.trees unconditionally, so this is a reliable witness
-	// that Close was actually invoked on the leaked-then-fixed mtree.
+	// MultiTree.Close nils out t.trees unconditionally, so this is a reliable witness that Close ran.
 	require.Nil(t, mtree.trees, "mtree must be closed on catchup failure, not leaked")
 }
 
-// TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure exercises the background
-// rewrite goroutine's own best-effort CatchupWAL call and checks that a failure there
-// is reported cleanly (no panic, no hang) via the result channel.
 func TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Load(dir, Options{

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -519,6 +519,96 @@ func TestCatchupWALNegativeEndVersion(t *testing.T) {
 	require.Error(t, db.CatchupWAL(db.wal, -1), "negative endVersion must return an error")
 }
 
+// corruptTrailingWALEntry appends a garbage WAL entry right after the wal's current
+// last index, so any CatchupWAL call that reaches it fails to unmarshal. It returns
+// the version the corrupt entry pretends to be, so callers can keep lastCommitInfo
+// consistent with the wal's reported committed version.
+func corruptTrailingWALEntry(t *testing.T, db *DB) int64 {
+	t.Helper()
+
+	lastIndex, err := db.wal.LastIndex()
+	require.NoError(t, err)
+
+	corruptIndex := lastIndex + 1
+	require.NoError(t, db.wal.Write(corruptIndex, []byte("not a valid WALEntry")))
+
+	return walVersion(corruptIndex, db.initialVersion)
+}
+
+// TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure verifies that when the
+// wal catch-up step in checkBackgroundSnapshotRewrite fails, the freshly loaded MultiTree
+// (which just mmap'd a whole snapshot's worth of files) is closed rather than leaked.
+func TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Load(dir, Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{Pairs: mockKVPairs("foo", "bar")}},
+	}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.RewriteSnapshot())
+
+	corruptVersion := corruptTrailingWALEntry(t, db)
+	// bypass the wal-catchup wait loop: we appended the corrupt entry directly to the
+	// wal, not through Commit, so db.lastCommitInfo.Version must be nudged to match the
+	// wal's reported committed version or checkBackgroundSnapshotRewrite would spin forever.
+	db.lastCommitInfo.Version = corruptVersion
+
+	mtree, err := LoadMultiTree(currentPath(db.dir), db.zeroCopy, db.cacheSize, db.chainId)
+	require.NoError(t, err)
+
+	ch := make(chan snapshotResult, 1)
+	ch <- snapshotResult{mtree: mtree}
+	db.snapshotRewriteChan = ch
+	db.snapshotRewriteCancel = func() {}
+
+	err = db.checkBackgroundSnapshotRewrite()
+	require.Error(t, err, "catchup failure must be propagated")
+
+	// MultiTree.Close nils out t.trees unconditionally, so this is a reliable witness
+	// that Close was actually invoked on the leaked-then-fixed mtree.
+	require.Nil(t, mtree.trees, "mtree must be closed on catchup failure, not leaked")
+}
+
+// TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure exercises the background
+// rewrite goroutine's own best-effort CatchupWAL call and checks that a failure there
+// is reported cleanly (no panic, no hang) via the result channel.
+func TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Load(dir, Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{Pairs: mockKVPairs("foo", "bar")}},
+	}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+
+	corruptTrailingWALEntry(t, db)
+
+	require.NoError(t, db.RewriteSnapshotBackground())
+
+	select {
+	case result := <-db.snapshotRewriteChan:
+		require.Error(t, result.err, "background catchup failure must be reported")
+		require.Nil(t, result.mtree, "no tree handed back on failure, so no way to leak it via the result")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for background snapshot rewrite result: goroutine likely hung")
+	}
+	db.snapshotRewriteChan = nil
+	db.snapshotRewriteCancel = nil
+}
+
 func TestZeroCopy(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{InitialStores: []string{testStoreName, test2StoreName}, CreateIfMissing: true, ZeroCopy: true}, TestAppChainID)
 	require.NoError(t, err)

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -635,8 +635,6 @@ func TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure(t *testing.T) {
 		db.snapshotRewriteChan = nil
 		db.snapshotRewriteCancel = nil
 	case <-time.After(5 * time.Second):
-		// leave snapshotRewriteChan/Cancel set so the deferred db.Close() still
-		// cancels and drains the goroutine instead of orphaning it.
 		db.snapshotRewriteCancel()
 		t.Fatal("timed out waiting for background snapshot rewrite result: goroutine likely hung")
 	}


### PR DESCRIPTION
### What
`memiavl/db.go`: both `checkBackgroundSnapshotRewrite` and the `rewriteSnapshotBackground` goroutine now close the freshly-loaded `MultiTree` when `CatchupWAL` fails, via `errors.Join(err, mtree.Close())`.

### Issue
On `CatchupWAL` failure, the error was returned/sent without closing the tree that had just been mmap'd from snapshot files, leaking mmap regions and file descriptors on every failed background rewrite attempt.

### Solution
Matches the existing `errors.Join(err, x.Close())` idiom already used in `Load()` and `reloadMultiTree` in this file — Close()'s own error is folded in, not swallowed.

### Test
`TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure` structurally verifies `Close()` ran (asserts `mtree.trees == nil`) for the main-thread path; confirmed by stashing the fix and reproducing the bug. `TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure` exercises the goroutine path end-to-end with a hang guard. `go test -race ./...`, `gofmt -l`, `golangci-lint run` all clean.