### PR TITLE
fix(memiavl): avoid walIndex underflow when pruning with initialVersion>1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#83](https://github.com/crypto-org-chain/cronos-store/pull/83) fix(memiavl): avoid walIndex underflow when pruning with initialVersion>1
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -609,8 +609,8 @@ func (db *DB) pruneSnapshots() {
 		}
 		db.earliestSnapshotCache.Store(earliestVersion)
 
-		// the genesis placeholder snapshot (version 0 or below initialVersion) has no
-		// corresponding wal entries yet, walIndex would underflow computing its index.
+		// guard against walIndex underflow: when earliestVersion < initialVersion-1,
+		// the genesis placeholder snapshot has no corresponding wal entries yet.
 		if earliestVersion+1 < int64(initialVersion) {
 			return
 		}

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -605,8 +605,14 @@ func (db *DB) pruneSnapshots() {
 		earliestVersion, err := firstSnapshotVersion(db.dir)
 		if err != nil {
 			db.logger.Error("failed to find first snapshot", "err", err)
-		} else {
-			db.earliestSnapshotCache.Store(earliestVersion)
+			return
+		}
+		db.earliestSnapshotCache.Store(earliestVersion)
+
+		// the genesis placeholder snapshot (version 0 or below initialVersion) has no
+		// corresponding wal entries yet, walIndex would underflow computing its index.
+		if earliestVersion+1 < int64(initialVersion) {
+			return
 		}
 
 		if err := wal.TruncateFront(walIndex(earliestVersion+1, initialVersion)); err != nil {

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -917,4 +918,131 @@ func TestEarliestVersionUnpruned(t *testing.T) {
 	earliest, err := db.EarliestVersion()
 	require.NoError(t, err)
 	require.Greater(t, earliest, int64(0), "EarliestVersion must not report height 0 for unpruned store")
+}
+
+// recordingLogger captures Error() calls so tests can assert on prune
+// failure/success behavior without depending on log output formatting.
+type recordingLogger struct {
+	mu     sync.Mutex
+	errors []string
+}
+
+func (l *recordingLogger) Debug(string, ...interface{}) {}
+func (l *recordingLogger) Info(string, ...interface{})  {}
+
+func (l *recordingLogger) Error(msg string, _ ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errors = append(l.errors, msg)
+}
+
+func (l *recordingLogger) Errors() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.errors...)
+}
+
+// waitPrune blocks until any in-flight pruneSnapshots goroutine has finished,
+// by acquiring and releasing the lock it holds for its duration.
+func waitPrune(db *DB) {
+	db.pruneSnapshotLock.Lock()
+	db.pruneSnapshotLock.Unlock() //nolint:staticcheck // empty section intentional: Lock blocks until prune goroutine finishes
+}
+
+// TestPruneSnapshotsFirstSnapshotVersionError verifies that when
+// firstSnapshotVersion fails (e.g. no snapshot directories present),
+// pruneSnapshots bails out instead of truncating the WAL using the zero
+// value earliestVersion defaults to, and leaves the earliest-snapshot cache
+// untouched.
+func TestPruneSnapshotsFirstSnapshotVersionError(t *testing.T) {
+	logger := &recordingLogger{}
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+		Logger:          logger,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	// initialVersion > 1 so that, on the old buggy code, falling through with
+	// earliestVersion's zero value would drive walIndex(1, 100) into
+	// underflow instead of harmlessly resolving to a no-op truncation.
+	require.NoError(t, db.SetInitialVersion(100))
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{Pairs: mockKVPairs("k", "v")}},
+	}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+
+	// seed a sane cache value so we can verify it's left untouched below.
+	db.earliestSnapshotCache.Store(1)
+
+	// remove every snapshot directory so firstSnapshotVersion errors out.
+	entries, err := os.ReadDir(db.dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.IsDir() {
+			require.NoError(t, os.RemoveAll(filepath.Join(db.dir, e.Name())))
+		}
+	}
+
+	db.pruneSnapshots()
+	waitPrune(db)
+
+	errs := logger.Errors()
+	require.Contains(t, errs, "failed to find first snapshot")
+	// the truncation path must not have been reached with the bogus zero value.
+	require.NotContains(t, errs, "failed to truncate wal")
+	require.EqualValues(t, 1, db.earliestSnapshotCache.Load(),
+		"cache must not be overwritten with the zero value on error")
+}
+
+// TestPruneSnapshotsInitialVersionUnderflowGuard verifies that when the
+// earliest remaining snapshot is still the genesis placeholder (version 0)
+// and initialVersion > 1, pruneSnapshots skips truncation instead of
+// computing walIndex(earliestVersion+1, initialVersion), which would
+// underflow to a huge uint64 and make TruncateFront fail with
+// ErrOutOfRange on every prune cycle.
+func TestPruneSnapshotsInitialVersionUnderflowGuard(t *testing.T) {
+	// sanity-check the underflow this guard prevents: without it,
+	// walIndex(earliestVersion+1, initialVersion) wraps to a huge uint64
+	// instead of erroring, matching the earliestVersion=0, initialVersion=100
+	// scenario exercised below.
+	require.Greater(t, walIndex(1, 100), uint64(1<<62),
+		"walIndex(1, 100) is expected to underflow without the guard")
+
+	logger := &recordingLogger{}
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+		Logger:          logger,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	require.NoError(t, db.SetInitialVersion(100))
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{Pairs: mockKVPairs("k", "v")}},
+	}))
+	v, err := db.Commit()
+	require.NoError(t, err)
+	require.EqualValues(t, 100, v)
+
+	// snapshot-0 (the genesis placeholder) is still on disk; no snapshot has
+	// been rewritten at or after initialVersion yet, so earliestVersion stays 0.
+	earliest, err := firstSnapshotVersion(db.dir)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, earliest)
+
+	db.pruneSnapshots()
+	waitPrune(db)
+
+	require.NotContains(t, logger.Errors(), "failed to truncate wal",
+		"guard must skip truncation instead of calling TruncateFront with an underflowed index")
+
+	// the WAL must be untouched: commits made before the guarded prune are
+	// still readable, proving no destructive truncation happened.
+	firstVersion, err := db.FirstVersion()
+	require.NoError(t, err)
+	require.EqualValues(t, 100, firstVersion)
 }

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -949,11 +949,6 @@ func waitPrune(db *DB) {
 	db.pruneSnapshotLock.Unlock() //nolint:staticcheck // empty section intentional: Lock blocks until prune goroutine finishes
 }
 
-// TestPruneSnapshotsFirstSnapshotVersionError verifies that when
-// firstSnapshotVersion fails (e.g. no snapshot directories present),
-// pruneSnapshots bails out instead of truncating the WAL using the zero
-// value earliestVersion defaults to, and leaves the earliest-snapshot cache
-// untouched.
 func TestPruneSnapshotsFirstSnapshotVersionError(t *testing.T) {
 	logger := &recordingLogger{}
 	db, err := Load(t.TempDir(), Options{
@@ -964,9 +959,8 @@ func TestPruneSnapshotsFirstSnapshotVersionError(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { require.NoError(t, db.Close()) }()
 
-	// initialVersion > 1 so that, on the old buggy code, falling through with
-	// earliestVersion's zero value would drive walIndex(1, 100) into
-	// underflow instead of harmlessly resolving to a no-op truncation.
+	// initialVersion > 1 so the old buggy code would drive walIndex(1, 100)
+	// into underflow instead of a harmless no-op.
 	require.NoError(t, db.SetInitialVersion(100))
 	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
 		{Name: testStoreName, Changeset: ChangeSet{Pairs: mockKVPairs("k", "v")}},
@@ -997,17 +991,9 @@ func TestPruneSnapshotsFirstSnapshotVersionError(t *testing.T) {
 		"cache must not be overwritten with the zero value on error")
 }
 
-// TestPruneSnapshotsInitialVersionUnderflowGuard verifies that when the
-// earliest remaining snapshot is still the genesis placeholder (version 0)
-// and initialVersion > 1, pruneSnapshots skips truncation instead of
-// computing walIndex(earliestVersion+1, initialVersion), which would
-// underflow to a huge uint64 and make TruncateFront fail with
-// ErrOutOfRange on every prune cycle.
 func TestPruneSnapshotsInitialVersionUnderflowGuard(t *testing.T) {
-	// sanity-check the underflow this guard prevents: without it,
-	// walIndex(earliestVersion+1, initialVersion) wraps to a huge uint64
-	// instead of erroring, matching the earliestVersion=0, initialVersion=100
-	// scenario exercised below.
+	// sanity-check that walIndex(1, 100) itself underflows, confirming the
+	// guard in pruneSnapshots is actually needed for this scenario.
 	require.Greater(t, walIndex(1, 100), uint64(1<<62),
 		"walIndex(1, 100) is expected to underflow without the guard")
 


### PR DESCRIPTION
### What
`memiavl/db.go`, `pruneSnapshots`: returns immediately on a `firstSnapshotVersion` error instead of falling through with `earliestVersion` stuck at 0, and adds a guard `if earliestVersion+1 < int64(initialVersion) { return }` before computing `walIndex(earliestVersion+1, initialVersion)`.

### Issue
For chains with `initialVersion > 1`, `walIndex` underflowed (uint64 wraparound), making `TruncateFront` fail with `ErrOutOfRange` on every single prune cycle.

### Solution
The guard boundary matches the `tidwall/wal` library's own index==0-invalid check exactly, and is a no-op when `initialVersion <= 1`, so normal pruning behavior is unaffected.

### Test
`TestPruneSnapshotsFirstSnapshotVersionError`, `TestPruneSnapshotsInitialVersionUnderflowGuard` — both confirmed to fail against the pre-fix code (via manual revert) and pass post-fix. `go test -race ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run` all clean.