### PR TITLE
fix(memiavl): compare against original file size in truncateCorruptedTail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#84](https://github.com/crypto-org-chain/cronos-store/pull/84) fix(memiavl): compare against original file size in truncateCorruptedTail
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/wal.go
+++ b/memiavl/wal.go
@@ -51,6 +51,7 @@ func truncateCorruptedTail(path string, format wal.LogFormat) error {
 	if err != nil {
 		return err
 	}
+	originalFileSize := len(data)
 	var pos int
 	for len(data) > 0 {
 		var n int
@@ -68,7 +69,9 @@ func truncateCorruptedTail(path string, format wal.LogFormat) error {
 		data = data[n:]
 		pos += n
 	}
-	if pos != len(data) {
+	// data shrinks as pos grows, so compare pos against the original size, not
+	// len(data): pos == len(data) mid-loop is a valid coincidence, not "fully consumed".
+	if pos < originalFileSize {
 		return os.Truncate(path, int64(pos))
 	}
 	return nil

--- a/memiavl/wal.go
+++ b/memiavl/wal.go
@@ -69,8 +69,8 @@ func truncateCorruptedTail(path string, format wal.LogFormat) error {
 		data = data[n:]
 		pos += n
 	}
-	// data shrinks as pos grows, so compare pos against the original size, not
-	// len(data): pos == len(data) mid-loop is a valid coincidence, not "fully consumed".
+	// len(data) shrinks as pos grows, so pos == len(data) can hold mid-loop;
+	// compare against originalFileSize to detect a truly incomplete parse.
 	if pos < originalFileSize {
 		return os.Truncate(path, int64(pos))
 	}

--- a/memiavl/wal.go
+++ b/memiavl/wal.go
@@ -69,9 +69,6 @@ func truncateCorruptedTail(path string, format wal.LogFormat) error {
 		data = data[n:]
 		pos += n
 	}
-	// After a corrupt entry breaks the loop, pos < originalFileSize.
-	// len(data) reflects remaining unprocessed bytes (always originalFileSize - pos),
-	// so comparing against it would give the same numeric value but obscures intent.
 	if pos < originalFileSize {
 		return os.Truncate(path, int64(pos))
 	}

--- a/memiavl/wal.go
+++ b/memiavl/wal.go
@@ -69,8 +69,9 @@ func truncateCorruptedTail(path string, format wal.LogFormat) error {
 		data = data[n:]
 		pos += n
 	}
-	// len(data) shrinks as pos grows, so pos == len(data) can hold mid-loop;
-	// compare against originalFileSize to detect a truly incomplete parse.
+	// After a corrupt entry breaks the loop, pos < originalFileSize.
+	// len(data) reflects remaining unprocessed bytes (always originalFileSize - pos),
+	// so comparing against it would give the same numeric value but obscures intent.
 	if pos < originalFileSize {
 		return os.Truncate(path, int64(pos))
 	}

--- a/memiavl/wal_test.go
+++ b/memiavl/wal_test.go
@@ -26,10 +26,7 @@ func TestCorruptedTail(t *testing.T) {
 		{"failure-3", []byte(`{"index":"1"}` + "\n"), 0},
 		{"failure-4", []byte(`{"index":"1","data":"?"}`), 0},
 		{"failure-5", []byte(`{"index":1,"data":"?"}` + "\n" + `{"index":"1","data":"?"}`), 1},
-		// Regression: the corrupt tail here is deliberately made the same length as
-		// the valid prefix consumed so far (23 bytes each), which used to make
-		// truncateCorruptedTail compare pos against len(data) instead of the
-		// original file size and skip truncation entirely.
+		// tail is 23 bytes to match the consumed prefix length, the pos == len(data) case.
 		{"failure-6-equal-length-tail", []byte(`{"index":1,"data":"?"}` + "\n" + strings.Repeat("?", 23)), 1},
 	}
 

--- a/memiavl/wal_test.go
+++ b/memiavl/wal_test.go
@@ -26,7 +26,7 @@ func TestCorruptedTail(t *testing.T) {
 		{"failure-3", []byte(`{"index":"1"}` + "\n"), 0},
 		{"failure-4", []byte(`{"index":"1","data":"?"}`), 0},
 		{"failure-5", []byte(`{"index":1,"data":"?"}` + "\n" + `{"index":"1","data":"?"}`), 1},
-		// tail is 23 bytes to match the consumed prefix length, the pos == len(data) case.
+		// entry is 23 bytes (including newline); tail is also 23 bytes to exercise pos == len(tail) parity.
 		{"failure-6-equal-length-tail", []byte(`{"index":1,"data":"?"}` + "\n" + strings.Repeat("?", 23)), 1},
 	}
 

--- a/memiavl/wal_test.go
+++ b/memiavl/wal_test.go
@@ -3,6 +3,7 @@ package memiavl
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,6 +26,11 @@ func TestCorruptedTail(t *testing.T) {
 		{"failure-3", []byte(`{"index":"1"}` + "\n"), 0},
 		{"failure-4", []byte(`{"index":"1","data":"?"}`), 0},
 		{"failure-5", []byte(`{"index":1,"data":"?"}` + "\n" + `{"index":"1","data":"?"}`), 1},
+		// Regression: the corrupt tail here is deliberately made the same length as
+		// the valid prefix consumed so far (23 bytes each), which used to make
+		// truncateCorruptedTail compare pos against len(data) instead of the
+		// original file size and skip truncation entirely.
+		{"failure-6-equal-length-tail", []byte(`{"index":1,"data":"?"}` + "\n" + strings.Repeat("?", 23)), 1},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What
`memiavl/wal.go`, `truncateCorruptedTail`: captures `originalFileSize := len(data)` before the parse loop and changes the final invariant check to `pos < originalFileSize` instead of `pos != len(data)`.

### Issue
The old comparison used the wrong invariant, so a corrupted tail that happened to land on a byte-length matching a re-derived value could silently pass through un-truncated.

### Solution
Compare parse position against the original file size captured up front, not a value that can drift during parsing.

### Test
Added a table-driven case `failure-6-equal-length-tail` to the existing `TestCorruptedTail` test — a 23-byte valid entry plus a 23-byte garbage tail with no trailing newline, engineered to hit the exact parity condition that triggered the bug. `go test -race ./...` full package passes all subtests.