### PR TITLE
fix(memiavl): close WAL after reading latest version in GetLatestVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#86](https://github.com/crypto-org-chain/cronos-store/pull/86) fix(memiavl): close WAL after reading latest version in GetLatestVersion
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -1332,6 +1332,9 @@ func GetLatestVersion(dir string) (int64, error) {
 	}
 	lastIndex, err := wal.LastIndex()
 	if err != nil {
+		return 0, errors.Join(err, wal.Close())
+	}
+	if err := wal.Close(); err != nil {
 		return 0, err
 	}
 	return walVersion(lastIndex, uint32(metadata.InitialVersion)), nil

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -917,4 +918,47 @@ func TestEarliestVersionUnpruned(t *testing.T) {
 	earliest, err := db.EarliestVersion()
 	require.NoError(t, err)
 	require.Greater(t, earliest, int64(0), "EarliestVersion must not report height 0 for unpruned store")
+}
+
+// TestGetLatestVersionClosesWAL verifies that GetLatestVersion doesn't leak the
+// WAL's open file descriptor. It lowers the process's open-file limit and calls
+// GetLatestVersion far more times than the limit allows; if the WAL were never
+// closed, the descriptors would accumulate and later calls would start failing
+// with "too many open files".
+func TestGetLatestVersionClosesWAL(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Load(dir, Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+			{Name: testStoreName, Changeset: ChangeSet{Pairs: mockKVPairs(fmt.Sprintf("k%d", i), "v")}},
+		}))
+		_, err := db.Commit()
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.Close())
+
+	var oldLimit syscall.Rlimit
+	require.NoError(t, syscall.Getrlimit(syscall.RLIMIT_NOFILE, &oldLimit))
+	defer func() {
+		require.NoError(t, syscall.Setrlimit(syscall.RLIMIT_NOFILE, &oldLimit))
+	}()
+
+	const lowLimit = 64
+	require.NoError(t, syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Cur: lowLimit, Max: oldLimit.Max}))
+
+	// Well beyond the lowered limit: a single leaked fd per call would exhaust
+	// it and start returning "too many open files" long before this many
+	// iterations complete.
+	const iterations = lowLimit * 4
+	for i := 0; i < iterations; i++ {
+		version, err := GetLatestVersion(dir)
+		require.NoError(t, err)
+		require.EqualValues(t, 3, version)
+	}
 }

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -920,11 +920,7 @@ func TestEarliestVersionUnpruned(t *testing.T) {
 	require.Greater(t, earliest, int64(0), "EarliestVersion must not report height 0 for unpruned store")
 }
 
-// TestGetLatestVersionClosesWAL verifies that GetLatestVersion doesn't leak the
-// WAL's open file descriptor. It lowers the process's open-file limit and calls
-// GetLatestVersion far more times than the limit allows; if the WAL were never
-// closed, the descriptors would accumulate and later calls would start failing
-// with "too many open files".
+// Lowers RLIMIT_NOFILE so a leaked fd per call would exhaust it quickly.
 func TestGetLatestVersionClosesWAL(t *testing.T) {
 	dir := t.TempDir()
 
@@ -952,9 +948,7 @@ func TestGetLatestVersionClosesWAL(t *testing.T) {
 	const lowLimit = 64
 	require.NoError(t, syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Cur: lowLimit, Max: oldLimit.Max}))
 
-	// Well beyond the lowered limit: a single leaked fd per call would exhaust
-	// it and start returning "too many open files" long before this many
-	// iterations complete.
+	// Well beyond lowLimit, so a leaked fd would surface as failures.
 	const iterations = lowLimit * 4
 	for i := 0; i < iterations; i++ {
 		version, err := GetLatestVersion(dir)


### PR DESCRIPTION
### What
`memiavl/db.go`, `GetLatestVersion`: closes the WAL it opens on both the error path (`errors.Join(err, wal.Close())`) and the success path (explicit `wal.Close()` before returning), matching the existing pattern in `Load()`.

### Issue
`GetLatestVersion` never closed the WAL it opened, leaking a file descriptor on every call.

### Solution
Matches the existing close-on-error idiom used elsewhere in this file.

### Test
`TestGetLatestVersionClosesWAL` lowers `RLIMIT_NOFILE` to 64 via `syscall.Setrlimit`, then calls `GetLatestVersion` 256 times and asserts no error. Confirmed via `git stash` that this fails with "too many open files" pre-fix and passes post-fix. `go test -race ./...`, `gofmt -l`, `golangci-lint run` all clean.