### PR TITLE
fix(memiavl): fsync directory after snapshot rename and current-symlink swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#87](https://github.com/crypto-org-chain/cronos-store/pull/87) fix(memiavl): fsync directory after snapshot rename and current-symlink swap
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -773,10 +773,8 @@ func (db *DB) RewriteSnapshotWithContext(ctx context.Context) error {
 	if err := os.Rename(path, filepath.Join(db.dir, snapshotDir)); err != nil {
 		return err
 	}
-	// fsync the directory before updating "current": WAL pruning that follows
-	// this rewrite truncates entries covering the new snapshot, so the rename
-	// must be durable first or a crash could leave neither the WAL entries nor
-	// a durable snapshot to reconstruct that range.
+	// Must be durable before WAL pruning removes the entries this snapshot
+	// replaces, or a crash could leave neither available to reconstruct state.
 	if err := fsyncDir(db.dir); err != nil {
 		return err
 	}
@@ -1298,11 +1296,8 @@ func traverseSnapshots(dir string, ascending bool, callback func(int64) (bool, e
 	return nil
 }
 
-// fsyncDir fsyncs a directory so that prior renames/symlink swaps of its
-// entries are durable, not just visible. Without this, a crash can lose the
-// directory entry update while later, independent operations (like WAL
-// truncation) that happened afterwards in program order are still durable,
-// leaving the db unable to find the snapshot it needs on restart.
+// fsyncDir makes prior renames/symlink swaps within it durable, not just
+// visible, so a crash can't lose them while later operations persist.
 func fsyncDir(path string) error {
 	f, err := os.Open(path)
 	if err != nil {

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -773,6 +773,13 @@ func (db *DB) RewriteSnapshotWithContext(ctx context.Context) error {
 	if err := os.Rename(path, filepath.Join(db.dir, snapshotDir)); err != nil {
 		return err
 	}
+	// fsync the directory before updating "current": WAL pruning that follows
+	// this rewrite truncates entries covering the new snapshot, so the rename
+	// must be durable first or a crash could leave neither the WAL entries nor
+	// a durable snapshot to reconstruct that range.
+	if err := fsyncDir(db.dir); err != nil {
+		return err
+	}
 	return updateCurrentSymlink(db.dir, snapshotDir)
 }
 
@@ -1244,7 +1251,12 @@ func updateCurrentSymlink(dir, snapshot string) error {
 		return err
 	}
 	// assuming file renaming operation is atomic
-	return os.Rename(tmpPath, currentPath(dir))
+	if err := os.Rename(tmpPath, currentPath(dir)); err != nil {
+		return err
+	}
+	// fsync so the symlink swap survives a crash; otherwise "current" can
+	// revert to the old (possibly pruned) snapshot on restart.
+	return fsyncDir(dir)
 }
 
 // traverseSnapshots traverse the snapshot list in specified order.
@@ -1284,6 +1296,19 @@ func traverseSnapshots(dir string, ascending bool, callback func(int64) (bool, e
 	}
 
 	return nil
+}
+
+// fsyncDir fsyncs a directory so that prior renames/symlink swaps of its
+// entries are durable, not just visible. Without this, a crash can lose the
+// directory entry update while later, independent operations (like WAL
+// truncation) that happened afterwards in program order are still durable,
+// leaving the db unable to find the snapshot it needs on restart.
+func fsyncDir(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	return errors.Join(f.Sync(), f.Close())
 }
 
 // atomicRemoveDir is equavalent to `mv snapshot snapshot-tmp && rm -r snapshot-tmp`

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -773,8 +773,6 @@ func (db *DB) RewriteSnapshotWithContext(ctx context.Context) error {
 	if err := os.Rename(path, filepath.Join(db.dir, snapshotDir)); err != nil {
 		return err
 	}
-	// Must be durable before WAL pruning removes the entries this snapshot
-	// replaces, or a crash could leave neither available to reconstruct state.
 	if err := fsyncDir(db.dir); err != nil {
 		return err
 	}
@@ -1252,8 +1250,7 @@ func updateCurrentSymlink(dir, snapshot string) error {
 	if err := os.Rename(tmpPath, currentPath(dir)); err != nil {
 		return err
 	}
-	// fsync so the symlink swap survives a crash; otherwise "current" can
-	// revert to the old (possibly pruned) snapshot on restart.
+
 	return fsyncDir(dir)
 }
 

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -42,6 +42,42 @@ func TestRewriteSnapshot(t *testing.T) {
 	}
 }
 
+func TestFsyncDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, fsyncDir(dir))
+
+	// fsyncDir should observe a rename performed just before it's called,
+	// mirroring how it's used after the snapshot/current-symlink renames.
+	oldPath := filepath.Join(dir, "old-name")
+	newPath := filepath.Join(dir, "new-name")
+	require.NoError(t, os.WriteFile(oldPath, []byte("data"), 0o600))
+	require.NoError(t, os.Rename(oldPath, newPath))
+	require.NoError(t, fsyncDir(dir))
+
+	_, err := os.Stat(newPath)
+	require.NoError(t, err)
+
+	// a non-existent directory should fail to open rather than silently succeed.
+	require.Error(t, fsyncDir(filepath.Join(dir, "does-not-exist")))
+}
+
+func TestUpdateCurrentSymlinkFsync(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "snapshot-a"), os.ModePerm))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "snapshot-b"), os.ModePerm))
+
+	require.NoError(t, updateCurrentSymlink(dir, "snapshot-a"))
+	target, err := os.Readlink(currentPath(dir))
+	require.NoError(t, err)
+	require.Equal(t, "snapshot-a", target)
+
+	// swap "current" again to exercise the rename+fsync path a second time.
+	require.NoError(t, updateCurrentSymlink(dir, "snapshot-b"))
+	target, err = os.Readlink(currentPath(dir))
+	require.NoError(t, err)
+	require.Equal(t, "snapshot-b", target)
+}
+
 func TestRemoveSnapshotDir(t *testing.T) {
 	dbDir := t.TempDir()
 	defer func(path string) {

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -58,7 +58,7 @@ func TestFsyncDir(t *testing.T) {
 	require.Error(t, fsyncDir(filepath.Join(dir, "does-not-exist")))
 }
 
-func TestUpdateCurrentSymlinkFsync(t *testing.T) {
+func TestUpdateCurrentSymlink(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "snapshot-a"), os.ModePerm))
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "snapshot-b"), os.ModePerm))

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -46,8 +46,6 @@ func TestFsyncDir(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, fsyncDir(dir))
 
-	// fsyncDir should observe a rename performed just before it's called,
-	// mirroring how it's used after the snapshot/current-symlink renames.
 	oldPath := filepath.Join(dir, "old-name")
 	newPath := filepath.Join(dir, "new-name")
 	require.NoError(t, os.WriteFile(oldPath, []byte("data"), 0o600))
@@ -57,7 +55,6 @@ func TestFsyncDir(t *testing.T) {
 	_, err := os.Stat(newPath)
 	require.NoError(t, err)
 
-	// a non-existent directory should fail to open rather than silently succeed.
 	require.Error(t, fsyncDir(filepath.Join(dir, "does-not-exist")))
 }
 
@@ -71,7 +68,6 @@ func TestUpdateCurrentSymlinkFsync(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "snapshot-a", target)
 
-	// swap "current" again to exercise the rename+fsync path a second time.
 	require.NoError(t, updateCurrentSymlink(dir, "snapshot-b"))
 	target, err = os.Readlink(currentPath(dir))
 	require.NoError(t, err)


### PR DESCRIPTION
### What
`memiavl/db.go`: adds an `fsyncDir(path string) error` helper, called on the containing directory after the snapshot-dir rename in `RewriteSnapshotWithContext` (before `updateCurrentSymlink`), and after the `current`-symlink rename in `updateCurrentSymlink`.

### Issue
Neither rename was followed by a directory fsync. On crash, the directory-entry update for the snapshot rename or the `current` symlink swap could be lost, while the later WAL truncation in `pruneSnapshots` (independently durable) survives — leaving the DB unable to find a snapshot covering the truncated WAL range.

### Solution
Standard "fsync the containing directory to persist a rename" pattern. File content itself is already fsynced elsewhere before the rename; this closes the directory-entry gap specifically. Verified the ordering is safe: both fsyncs complete inside `RewriteSnapshotWithContext`'s synchronous call chain before it signals completion via the result channel, and `pruneSnapshots` only runs after that channel receive under `db.mtx` — no race window.

### Test
`TestFsyncDir`, `TestUpdateCurrentSymlink`, plus existing `TestRewriteSnapshot`/`TestRewriteSnapshotBackground` continue to pass, exercising the new fsync calls in the normal path. `go test -race ./...`, `gofmt -l`, `golangci-lint run` all clean.