### PR TITLE
fix(versiondb): strip store prefix from iterator Domain() bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#88](https://github.com/crypto-org-chain/cronos-store/pull/88) fix(versiondb): strip store prefix from iterator Domain() bounds
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/versiondb/tsrocksdb/iterator.go
+++ b/versiondb/tsrocksdb/iterator.go
@@ -73,7 +73,7 @@ func newRocksDBIterator(source *grocksdb.Iterator, prefix, start, end, domainSta
 }
 
 // Domain implements Iterator. Returns the unprefixed bounds to match Key()'s
-// stripped-prefix output, not the internal prefixed start/end.
+// stripped-prefix output.
 func (itr *rocksDBIterator) Domain() ([]byte, []byte) {
 	return itr.domainStart, itr.domainEnd
 }

--- a/versiondb/tsrocksdb/iterator.go
+++ b/versiondb/tsrocksdb/iterator.go
@@ -11,11 +11,8 @@ import (
 type rocksDBIterator struct {
 	source             *grocksdb.Iterator
 	prefix, start, end []byte
-	// domainStart, domainEnd are the caller-provided bounds before the store
-	// prefix was applied, i.e. what Domain() must return to stay consistent
-	// with the unprefixed keys returned by Key(). Kept separate from
-	// start/end (which are prefixed and used for Valid()'s bound checks),
-	// matching cosmos-sdk's store/v2/prefix.prefixIterator convention.
+	// domainStart, domainEnd are the caller's unprefixed bounds; start/end
+	// get rewritten to the prefixed range used for Valid()'s checks.
 	domainStart, domainEnd []byte
 	isReverse              bool
 	isInvalid              bool
@@ -75,9 +72,8 @@ func newRocksDBIterator(source *grocksdb.Iterator, prefix, start, end, domainSta
 	return it
 }
 
-// Domain implements Iterator. It returns the caller-provided bounds in the
-// unprefixed keyspace, matching Key()'s stripped-prefix output (see
-// cosmos-sdk store/v2/prefix.prefixIterator.Domain for the same convention).
+// Domain implements Iterator. Returns the unprefixed bounds to match Key()'s
+// stripped-prefix output, not the internal prefixed start/end.
 func (itr *rocksDBIterator) Domain() ([]byte, []byte) {
 	return itr.domainStart, itr.domainEnd
 }

--- a/versiondb/tsrocksdb/iterator.go
+++ b/versiondb/tsrocksdb/iterator.go
@@ -11,8 +11,14 @@ import (
 type rocksDBIterator struct {
 	source             *grocksdb.Iterator
 	prefix, start, end []byte
-	isReverse          bool
-	isInvalid          bool
+	// domainStart, domainEnd are the caller-provided bounds before the store
+	// prefix was applied, i.e. what Domain() must return to stay consistent
+	// with the unprefixed keys returned by Key(). Kept separate from
+	// start/end (which are prefixed and used for Valid()'s bound checks),
+	// matching cosmos-sdk's store/v2/prefix.prefixIterator convention.
+	domainStart, domainEnd []byte
+	isReverse              bool
+	isInvalid              bool
 
 	// see: https://github.com/crypto-org-chain/cronos-store/issues/1683
 	skipVersionZero bool
@@ -29,7 +35,7 @@ type rocksDBIterator struct {
 
 var _ versiondb.Iterator = (*rocksDBIterator)(nil)
 
-func newRocksDBIterator(source *grocksdb.Iterator, prefix, start, end []byte, isReverse, skipVersionZero bool, readOpts *grocksdb.ReadOptions) *rocksDBIterator {
+func newRocksDBIterator(source *grocksdb.Iterator, prefix, start, end, domainStart, domainEnd []byte, isReverse, skipVersionZero bool, readOpts *grocksdb.ReadOptions) *rocksDBIterator {
 	if isReverse {
 		if end == nil {
 			source.SeekToLast()
@@ -57,6 +63,8 @@ func newRocksDBIterator(source *grocksdb.Iterator, prefix, start, end []byte, is
 		prefix:          prefix,
 		start:           start,
 		end:             end,
+		domainStart:     domainStart,
+		domainEnd:       domainEnd,
 		isReverse:       isReverse,
 		isInvalid:       false,
 		skipVersionZero: skipVersionZero,
@@ -67,9 +75,11 @@ func newRocksDBIterator(source *grocksdb.Iterator, prefix, start, end []byte, is
 	return it
 }
 
-// Domain implements Iterator.
+// Domain implements Iterator. It returns the caller-provided bounds in the
+// unprefixed keyspace, matching Key()'s stripped-prefix output (see
+// cosmos-sdk store/v2/prefix.prefixIterator.Domain for the same convention).
 func (itr *rocksDBIterator) Domain() ([]byte, []byte) {
-	return itr.start, itr.end
+	return itr.domainStart, itr.domainEnd
 }
 
 // Valid implements Iterator.

--- a/versiondb/tsrocksdb/iterator_test.go
+++ b/versiondb/tsrocksdb/iterator_test.go
@@ -6,10 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestIteratorDomainNilBounds verifies Domain() returns (nil, nil) when the
-// caller passed nil start/end, mirroring cosmos-sdk's prefix.prefixIterator
-// convention (see store/v2/prefix.Domain) rather than leaking the internal
-// prefix-derived bounds used to scope the underlying rocksdb iterator.
 func TestIteratorDomainNilBounds(t *testing.T) {
 	store, err := NewStore(t.TempDir())
 	require.NoError(t, err)
@@ -25,9 +21,6 @@ func TestIteratorDomainNilBounds(t *testing.T) {
 	require.Nil(t, end)
 }
 
-// TestIteratorDomainExplicitBounds verifies Domain() returns the caller's
-// original, unprefixed start/end -- exactly what Key() strips its results
-// down to -- rather than the store-prefixed bounds used internally.
 func TestIteratorDomainExplicitBounds(t *testing.T) {
 	store, err := NewStore(t.TempDir())
 	require.NoError(t, err)
@@ -44,10 +37,6 @@ func TestIteratorDomainExplicitBounds(t *testing.T) {
 	require.Equal(t, explicitEnd, end)
 }
 
-// TestIteratorDomainMixedBounds verifies a nil start with an explicit end
-// (and vice versa) round-trip correctly, since iterateWithPrefix computes a
-// prefix-derived end bound when the caller passes end=nil, which must not be
-// mistaken for an explicit bound when reconstructing Domain().
 func TestIteratorDomainMixedBounds(t *testing.T) {
 	store, err := NewStore(t.TempDir())
 	require.NoError(t, err)

--- a/versiondb/tsrocksdb/iterator_test.go
+++ b/versiondb/tsrocksdb/iterator_test.go
@@ -1,0 +1,70 @@
+package tsrocksdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIteratorDomainNilBounds verifies Domain() returns (nil, nil) when the
+// caller passed nil start/end, mirroring cosmos-sdk's prefix.prefixIterator
+// convention (see store/v2/prefix.Domain) rather than leaking the internal
+// prefix-derived bounds used to scope the underlying rocksdb iterator.
+func TestIteratorDomainNilBounds(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	require.NoError(t, store.PutAtVersion(1, nil))
+
+	itr, err := store.IteratorAtVersion(testStoreKey, nil, nil, nil)
+	require.NoError(t, err)
+	defer itr.Close()
+
+	start, end := itr.Domain()
+	require.Nil(t, start)
+	require.Nil(t, end)
+}
+
+// TestIteratorDomainExplicitBounds verifies Domain() returns the caller's
+// original, unprefixed start/end -- exactly what Key() strips its results
+// down to -- rather than the store-prefixed bounds used internally.
+func TestIteratorDomainExplicitBounds(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	explicitStart := []byte("aaa")
+	explicitEnd := []byte("zzz")
+
+	itr, err := store.IteratorAtVersion(testStoreKey, explicitStart, explicitEnd, nil)
+	require.NoError(t, err)
+	defer itr.Close()
+
+	start, end := itr.Domain()
+	require.Equal(t, explicitStart, start)
+	require.Equal(t, explicitEnd, end)
+}
+
+// TestIteratorDomainMixedBounds verifies a nil start with an explicit end
+// (and vice versa) round-trip correctly, since iterateWithPrefix computes a
+// prefix-derived end bound when the caller passes end=nil, which must not be
+// mistaken for an explicit bound when reconstructing Domain().
+func TestIteratorDomainMixedBounds(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	explicitEnd := []byte("zzz")
+	itr, err := store.IteratorAtVersion(testStoreKey, nil, explicitEnd, nil)
+	require.NoError(t, err)
+	start, end := itr.Domain()
+	require.Nil(t, start)
+	require.Equal(t, explicitEnd, end)
+	require.NoError(t, itr.Close())
+
+	explicitStart := []byte("aaa")
+	itr2, err := store.IteratorAtVersion(testStoreKey, explicitStart, nil, nil)
+	require.NoError(t, err)
+	start, end = itr2.Domain()
+	require.Equal(t, explicitStart, start)
+	require.Nil(t, end)
+	require.NoError(t, itr2.Close())
+}

--- a/versiondb/tsrocksdb/iterator_test.go
+++ b/versiondb/tsrocksdb/iterator_test.go
@@ -10,9 +10,20 @@ func TestIteratorDomainNilBounds(t *testing.T) {
 	store, err := NewStore(t.TempDir())
 	require.NoError(t, err)
 
-	require.NoError(t, store.PutAtVersion(1, nil))
-
 	itr, err := store.IteratorAtVersion(testStoreKey, nil, nil, nil)
+	require.NoError(t, err)
+	defer itr.Close()
+
+	start, end := itr.Domain()
+	require.Nil(t, start)
+	require.Nil(t, end)
+}
+
+func TestReverseIteratorDomainNilBounds(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	require.NoError(t, err)
+
+	itr, err := store.ReverseIteratorAtVersion(testStoreKey, nil, nil, nil)
 	require.NoError(t, err)
 	defer itr.Close()
 

--- a/versiondb/tsrocksdb/store.go
+++ b/versiondb/tsrocksdb/store.go
@@ -166,11 +166,12 @@ func (s Store) iteratorAtVersion(storeKey string, start, end []byte, version *in
 	}
 
 	prefix := storePrefix(storeKey)
+	domainStart, domainEnd := start, end
 	start, end = iterateWithPrefix(prefix, start, end)
 
 	readOpts := newTSReadOptions(version)
 	itr := s.db.NewIteratorCF(readOpts, s.cfHandle)
-	return newRocksDBIterator(itr, prefix, start, end, reverse, s.skipVersionZero, readOpts), nil
+	return newRocksDBIterator(itr, prefix, start, end, domainStart, domainEnd, reverse, s.skipVersionZero, readOpts), nil
 }
 
 // FeedChangeSet is used to migrate legacy change sets into versiondb


### PR DESCRIPTION
### What
`versiondb/tsrocksdb/iterator.go` and `store.go`: adds `domainStart, domainEnd []byte` fields to `rocksDBIterator`, populated in `iteratorAtVersion` with the caller's original unprefixed bounds before `iterateWithPrefix` rewrites the local `start`/`end` to prefixed slices. `Domain()` now returns these fields directly.

### Issue
`Domain()` returned the raw store-prefixed bounds while `Key()` strips the prefix from returned keys, so callers couldn't compare `Key()` output against `Domain()` bounds, and `Domain()` never returned `nil` even when the caller passed `nil`.

### Solution
Follows cosmos-sdk's own `store/v2/prefix.prefixIterator` convention exactly: store the original, unprefixed bounds separately from the prefixed bounds used internally for `Valid()`'s checks, rather than trying to reconstruct them by stripping prefix bytes back out (fragile around nil vs. `cpIncr`-derived end bounds).

### Test
`TestIteratorDomainNilBounds`, `TestIteratorDomainExplicitBounds`, `TestIteratorDomainMixedBounds` in `iterator_test.go`. Built against a real RocksDB v10.9.1 and ran `go test ./tsrocksdb/...` — passes, including these three new tests.