### PR TITLE
fix(versiondb): close store on all to-versiondb error paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#89](https://github.com/crypto-org-chain/cronos-store/pull/89) fix(versiondb): close store on all to-versiondb error paths
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.
 - [#72](https://github.com/crypto-org-chain/cronos-store/pull/72) fix(versiondb): mark s/latest only after a clean snapshot read.

--- a/versiondb/client/to_versiondb.go
+++ b/versiondb/client/to_versiondb.go
@@ -21,8 +21,6 @@ func ChangeSetToVersionDBCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Ensure the RocksDB handle/lock is released on every exit path,
-			// without clobbering an earlier error.
 			defer func() {
 				if cerr := versionDB.Close(); cerr != nil && err == nil {
 					err = cerr

--- a/versiondb/client/to_versiondb.go
+++ b/versiondb/client/to_versiondb.go
@@ -37,7 +37,14 @@ func ChangeSetToVersionDBCmd() *cobra.Command {
 				}
 			}
 
-			return nil
+			// Flush the memtable to disk and close the store before reporting
+			// success, otherwise a power loss right after this command prints
+			// "success" can silently lose the tail of the migrated changesets,
+			// with no way for a re-run to detect the loss.
+			if err := versionDB.Flush(); err != nil {
+				return err
+			}
+			return versionDB.Close()
 		},
 	}
 

--- a/versiondb/client/to_versiondb.go
+++ b/versiondb/client/to_versiondb.go
@@ -21,9 +21,8 @@ func ChangeSetToVersionDBCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// Close the store on every exit path (including early errors from
-			// FeedChangeSet/Flush) so the RocksDB handle and its exclusive LOCK
-			// file are never leaked.
+			// Ensure the RocksDB handle/lock is released on every exit path,
+			// without clobbering an earlier error.
 			defer func() {
 				if cerr := versionDB.Close(); cerr != nil && err == nil {
 					err = cerr
@@ -45,11 +44,8 @@ func ChangeSetToVersionDBCmd() *cobra.Command {
 				}
 			}
 
-			// Flush the memtable to disk before reporting success, otherwise a
-			// power loss right after this command prints "success" can silently
-			// lose the tail of the migrated changesets, with no way for a re-run
-			// to detect the loss. The deferred Close above releases the store
-			// afterwards on this and every other exit path.
+			// Flush before reporting success, so a crash right after can't
+			// silently lose the tail of the migrated changesets.
 			return versionDB.Flush()
 		},
 	}

--- a/versiondb/client/to_versiondb.go
+++ b/versiondb/client/to_versiondb.go
@@ -11,7 +11,7 @@ func ChangeSetToVersionDBCmd() *cobra.Command {
 		Use:   "to-versiondb versiondb-path plain-1 [plain-2] ...",
 		Short: "Feed change set files into versiondb",
 		Args:  cobra.MinimumNArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			store, err := cmd.Flags().GetString(flagStore)
 			if err != nil {
 				return err
@@ -21,6 +21,14 @@ func ChangeSetToVersionDBCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Close the store on every exit path (including early errors from
+			// FeedChangeSet/Flush) so the RocksDB handle and its exclusive LOCK
+			// file are never leaked.
+			defer func() {
+				if cerr := versionDB.Close(); cerr != nil && err == nil {
+					err = cerr
+				}
+			}()
 
 			for _, plainFile := range args[1:] {
 				if err := withChangeSetFile(plainFile, func(reader Reader) error {
@@ -37,14 +45,12 @@ func ChangeSetToVersionDBCmd() *cobra.Command {
 				}
 			}
 
-			// Flush the memtable to disk and close the store before reporting
-			// success, otherwise a power loss right after this command prints
-			// "success" can silently lose the tail of the migrated changesets,
-			// with no way for a re-run to detect the loss.
-			if err := versionDB.Flush(); err != nil {
-				return err
-			}
-			return versionDB.Close()
+			// Flush the memtable to disk before reporting success, otherwise a
+			// power loss right after this command prints "success" can silently
+			// lose the tail of the migrated changesets, with no way for a re-run
+			// to detect the loss. The deferred Close above releases the store
+			// afterwards on this and every other exit path.
+			return versionDB.Flush()
 		},
 	}
 

--- a/versiondb/client/to_versiondb_test.go
+++ b/versiondb/client/to_versiondb_test.go
@@ -57,10 +57,14 @@ func TestChangeSetToVersionDBCmdDurablyPersists(t *testing.T) {
 	require.Equal(t, []byte("v2"), v2)
 }
 
-// TestChangeSetToVersionDBCmdErrorDoesNotFlushOrClose verifies that a
-// mid-migration failure surfaces the underlying error and does not reach
-// the flush/close success path.
-func TestChangeSetToVersionDBCmdErrorDoesNotFlushOrClose(t *testing.T) {
+// TestChangeSetToVersionDBCmdErrorReleasesStore verifies that a mid-migration
+// failure both surfaces the underlying error and still releases the RocksDB
+// handle/lock on the store it opened. It mirrors
+// TestChangeSetToVersionDBCmdDurablyPersists by reopening a fresh Store
+// against the same directory: RocksDB's exclusive file lock means that only
+// succeeds if the command's own handle was actually closed on the error
+// path, not just left open with the error silently eaten.
+func TestChangeSetToVersionDBCmdErrorReleasesStore(t *testing.T) {
 	dir := t.TempDir()
 	dbDir := filepath.Join(dir, "versiondb")
 
@@ -73,4 +77,11 @@ func TestChangeSetToVersionDBCmdErrorDoesNotFlushOrClose(t *testing.T) {
 	cmd := ChangeSetToVersionDBCmd()
 	cmd.SetArgs([]string{dbDir, badFile, "--" + flagStore, testStoreKey})
 	require.Error(t, cmd.Execute())
+
+	// Reopening the same directory only succeeds if the command closed its
+	// own RocksDB handle on the error path; otherwise this fails with a
+	// "lock hold by current process" IO error.
+	reopened, err := tsrocksdb.NewStore(dbDir)
+	require.NoError(t, err)
+	require.NoError(t, reopened.Close())
 }

--- a/versiondb/client/to_versiondb_test.go
+++ b/versiondb/client/to_versiondb_test.go
@@ -11,14 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestChangeSetToVersionDBCmdDurablyPersists is a regression test for the
-// to-versiondb command reporting success without flushing/closing the
-// store: it feeds a change set through the real command, then reopens a
-// brand-new Store against the same directory (which only succeeds once the
-// original RocksDB handle has actually been closed) and verifies the fed
-// data is readable from that fresh handle. This is different from just
-// querying versionDB in-process, which would pass even if the writes were
-// only sitting in memory/OS buffers and never durably reached disk.
 func TestChangeSetToVersionDBCmdDurablyPersists(t *testing.T) {
 	dir := t.TempDir()
 	dbDir := filepath.Join(dir, "versiondb")
@@ -39,10 +31,8 @@ func TestChangeSetToVersionDBCmdDurablyPersists(t *testing.T) {
 	cmd.SetArgs([]string{dbDir, changeSetFile, "--" + flagStore, testStoreKey})
 	require.NoError(t, cmd.Execute())
 
-	// Reopening the same directory only succeeds if the command actually
-	// closed its own RocksDB handle (RocksDB holds an exclusive file lock),
-	// which in turn proves the command didn't just leave the store open and
-	// return "success" while writes were still pending.
+	// Reopening forces a real RocksDB lock check, proving the command
+	// actually closed its own handle.
 	reopened, err := tsrocksdb.NewStore(dbDir)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, reopened.Close()) }()
@@ -57,20 +47,10 @@ func TestChangeSetToVersionDBCmdDurablyPersists(t *testing.T) {
 	require.Equal(t, []byte("v2"), v2)
 }
 
-// TestChangeSetToVersionDBCmdErrorReleasesStore verifies that a mid-migration
-// failure both surfaces the underlying error and still releases the RocksDB
-// handle/lock on the store it opened. It mirrors
-// TestChangeSetToVersionDBCmdDurablyPersists by reopening a fresh Store
-// against the same directory: RocksDB's exclusive file lock means that only
-// succeeds if the command's own handle was actually closed on the error
-// path, not just left open with the error silently eaten.
 func TestChangeSetToVersionDBCmdErrorReleasesStore(t *testing.T) {
 	dir := t.TempDir()
 	dbDir := filepath.Join(dir, "versiondb")
 
-	// Not a valid change set file: the header can't be parsed, so
-	// IterateChangeSets/withChangeSetFile returns an error before the loop
-	// completes.
 	badFile := filepath.Join(dir, "bad.plain")
 	require.NoError(t, os.WriteFile(badFile, []byte{0x01, 0x02, 0x03}, 0o600))
 
@@ -78,9 +58,7 @@ func TestChangeSetToVersionDBCmdErrorReleasesStore(t *testing.T) {
 	cmd.SetArgs([]string{dbDir, badFile, "--" + flagStore, testStoreKey})
 	require.Error(t, cmd.Execute())
 
-	// Reopening the same directory only succeeds if the command closed its
-	// own RocksDB handle on the error path; otherwise this fails with a
-	// "lock hold by current process" IO error.
+	// Reopening forces a real RocksDB lock check on the error path too.
 	reopened, err := tsrocksdb.NewStore(dbDir)
 	require.NoError(t, err)
 	require.NoError(t, reopened.Close())

--- a/versiondb/client/to_versiondb_test.go
+++ b/versiondb/client/to_versiondb_test.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cosmos/iavl"
+	"github.com/crypto-org-chain/cronos-store/versiondb/tsrocksdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestChangeSetToVersionDBCmdDurablyPersists is a regression test for the
+// to-versiondb command reporting success without flushing/closing the
+// store: it feeds a change set through the real command, then reopens a
+// brand-new Store against the same directory (which only succeeds once the
+// original RocksDB handle has actually been closed) and verifies the fed
+// data is readable from that fresh handle. This is different from just
+// querying versionDB in-process, which would pass even if the writes were
+// only sitting in memory/OS buffers and never durably reached disk.
+func TestChangeSetToVersionDBCmdDurablyPersists(t *testing.T) {
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "versiondb")
+
+	changeSet := &iavl.ChangeSet{
+		Pairs: []*iavl.KVPair{
+			{Key: []byte("k1"), Value: []byte("v1")},
+			{Key: []byte("k2"), Value: []byte("v2")},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteChangeSet(&buf, 1, changeSet))
+	changeSetFile := filepath.Join(dir, "changeset.plain")
+	require.NoError(t, os.WriteFile(changeSetFile, buf.Bytes(), 0o600))
+
+	cmd := ChangeSetToVersionDBCmd()
+	cmd.SetArgs([]string{dbDir, changeSetFile, "--" + flagStore, testStoreKey})
+	require.NoError(t, cmd.Execute())
+
+	// Reopening the same directory only succeeds if the command actually
+	// closed its own RocksDB handle (RocksDB holds an exclusive file lock),
+	// which in turn proves the command didn't just leave the store open and
+	// return "success" while writes were still pending.
+	reopened, err := tsrocksdb.NewStore(dbDir)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, reopened.Close()) }()
+
+	version := int64(1)
+	v1, err := reopened.GetAtVersion(testStoreKey, []byte("k1"), &version)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v1"), v1)
+
+	v2, err := reopened.GetAtVersion(testStoreKey, []byte("k2"), &version)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v2"), v2)
+}
+
+// TestChangeSetToVersionDBCmdErrorDoesNotFlushOrClose verifies that a
+// mid-migration failure surfaces the underlying error and does not reach
+// the flush/close success path.
+func TestChangeSetToVersionDBCmdErrorDoesNotFlushOrClose(t *testing.T) {
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "versiondb")
+
+	// Not a valid change set file: the header can't be parsed, so
+	// IterateChangeSets/withChangeSetFile returns an error before the loop
+	// completes.
+	badFile := filepath.Join(dir, "bad.plain")
+	require.NoError(t, os.WriteFile(badFile, []byte{0x01, 0x02, 0x03}, 0o600))
+
+	cmd := ChangeSetToVersionDBCmd()
+	cmd.SetArgs([]string{dbDir, badFile, "--" + flagStore, testStoreKey})
+	require.Error(t, cmd.Execute())
+}

--- a/versiondb/tsrocksdb/store.go
+++ b/versiondb/tsrocksdb/store.go
@@ -239,9 +239,7 @@ func (s Store) Flush() error {
 	)
 }
 
-// Close releases the underlying RocksDB handles. Callers that need the
-// writes to be durable on disk before closing should call Flush first;
-// Close itself does not flush the memtable.
+// Close does not flush the memtable; call Flush first if durability is needed.
 func (s Store) Close() error {
 	s.cfHandle.Destroy()
 	s.db.Close()

--- a/versiondb/tsrocksdb/store.go
+++ b/versiondb/tsrocksdb/store.go
@@ -239,6 +239,15 @@ func (s Store) Flush() error {
 	)
 }
 
+// Close releases the underlying RocksDB handles. Callers that need the
+// writes to be durable on disk before closing should call Flush first;
+// Close itself does not flush the memtable.
+func (s Store) Close() error {
+	s.cfHandle.Destroy()
+	s.db.Close()
+	return nil
+}
+
 // FixData fixes wrong data written in versiondb due to rocksdb upgrade, the operation is idempotent.
 // see: https://github.com/crypto-org-chain/cronos-store/issues/1683
 // call this before `SetSkipVersionZero(true)`.


### PR DESCRIPTION
### What
`versiondb/client/to_versiondb.go`: `RunE` now uses a named return and a `defer` that unconditionally closes the opened `Store` right after `NewStore` succeeds, only surfacing `Close`'s own error if the command didn't already fail for another reason. `versiondb/tsrocksdb/store.go` gains a `Store.Close()` method (destroys the column family handle, then closes the DB handle).

### Issue
The `to-versiondb` command declared success with no flush/close/sync before returning, and on any error path never called `Close()` at all — leaking the RocksDB handle and its exclusive LOCK file. Reproduced concretely: ran the command against a malformed change-set file, then failed to reopen a fresh `Store` at the same directory with "lock hold by current process".

### Solution
A `defer` covers every exit path (loop error, `Flush()` error, success) instead of only calling `Flush()`/`Close()` after the loop succeeds. The clobber-avoidance check (`if cerr != nil && err == nil`) ensures a real `Flush`/loop error is never hidden by a `Close`-only failure.

### Test
`TestChangeSetToVersionDBCmdDurablyPersists` reopens a fresh `Store` at the same path after success, which only works if the original handle was truly closed. `TestChangeSetToVersionDBCmdErrorReleasesStore` does the same after a forced error path. Confirmed by reverting to the pre-fix code that the latter fails with a RocksDB lock error, then passes again with the fix restored. Built against real RocksDB v10.9.1; `go build`, `go vet`, `go test ./client/... ./tsrocksdb/...`, `gofmt -l`, `golangci-lint run` all clean.