### PR TITLE
fix(versiondb): bump every store's tree version in verifyOneStore, not just changed ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#90](https://github.com/crypto-org-chain/cronos-store/pull/90) fix(versiondb): bump every store's tree version in verifyOneStore, not just changed ones
 - [#76](https://github.com/crypto-org-chain/cronos-store/pull/76) fix(store): validate memiavl tree membership on load.
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.

--- a/versiondb/client/verify.go
+++ b/versiondb/client/verify.go
@@ -216,6 +216,12 @@ func verifyOneStore(tree *memiavl.Tree, store, changeSetDir, saveSnapshot string
 					return true, nil
 				}
 
+				// changesets only cover versions this store touched; bump through the gap so it
+				// stays in lockstep with the live path, which advances every store every block.
+				if err := advanceTreeVersion(tree, version-1); err != nil {
+					return false, err
+				}
+
 				// no need to update hashes for intermediate versions.
 				tree.ApplyChangeSet(convertChangeSet(changeSet))
 				_, v, err := tree.SaveVersion(false)
@@ -243,6 +249,13 @@ func verifyOneStore(tree *memiavl.Tree, store, changeSetDir, saveSnapshot string
 		return nil, err
 	}
 
+	// no more changesets for this store; catch up to targetVersion like the live path would.
+	if targetVersion > 0 {
+		if err := advanceTreeVersion(tree, targetVersion); err != nil {
+			return nil, err
+		}
+	}
+
 	if len(saveSnapshot) > 0 {
 		snapshotDir := filepath.Join(saveSnapshot, store)
 		if err := os.MkdirAll(snapshotDir, os.ModePerm); err != nil {
@@ -257,6 +270,18 @@ func verifyOneStore(tree *memiavl.Tree, store, changeSetDir, saveSnapshot string
 		Name:     store,
 		CommitId: lastCommitID(tree),
 	}, nil
+}
+
+// advanceTreeVersion bumps `tree` with no-op saves up to `target`, without applying any
+// changeset. Used to keep a store's version in lockstep with the live path, which advances
+// every store's tree version every block regardless of whether it changed.
+func advanceTreeVersion(tree *memiavl.Tree, target int64) error {
+	for tree.Version() < target {
+		if _, _, err := tree.SaveVersion(false); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // lastCommitID build `CommitID` from a memiavl tree.

--- a/versiondb/client/verify.go
+++ b/versiondb/client/verify.go
@@ -231,6 +231,8 @@ func verifyOneStore(tree *memiavl.Tree, store, changeSetDir, saveSnapshot string
 				if v != version {
 					return false, fmt.Errorf("version don't match: %d != %d", v, version)
 				}
+				// gap-filling above still runs even when targetVersion == 0 (exhaust all files); this
+				// only controls whether the loop stops early once targetVersion is reached.
 				return targetVersion == 0 || v < targetVersion, nil
 			})
 

--- a/versiondb/client/verify_test.go
+++ b/versiondb/client/verify_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +35,7 @@ func writeStoreChangeSet(t *testing.T, changeSetDir, store string, versions []in
 	storeDir := filepath.Join(changeSetDir, store)
 	require.NoError(t, os.MkdirAll(storeDir, os.ModePerm))
 
-	fp, err := os.Create(filepath.Join(storeDir, "block-0"))
+	fp, err := os.Create(filepath.Join(storeDir, fmt.Sprintf("block-%d", versions[0])))
 	require.NoError(t, err)
 	defer fp.Close()
 

--- a/versiondb/client/verify_test.go
+++ b/versiondb/client/verify_test.go
@@ -1,9 +1,14 @@
 package client
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/cosmos/iavl"
 	"github.com/stretchr/testify/require"
+
+	"github.com/crypto-org-chain/cronos-store/memiavl"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 )
@@ -18,4 +23,64 @@ func TestBuildCommitInfoUsesVersionParam(t *testing.T) {
 
 	require.Equal(t, int64(10), ci.Version, "must use the passed version, not storeInfos[0]'s")
 	require.Equal(t, "a", ci.StoreInfos[0].Name, "storeInfos should be sorted by name")
+}
+
+// writeStoreChangeSet writes a single change set file for `store` containing entries only for the
+// given versions (mimicking a real dump, where a store's changeset file only records the versions
+// where that specific store changed).
+func writeStoreChangeSet(t *testing.T, changeSetDir, store string, versions []int64) {
+	t.Helper()
+
+	storeDir := filepath.Join(changeSetDir, store)
+	require.NoError(t, os.MkdirAll(storeDir, os.ModePerm))
+
+	fp, err := os.Create(filepath.Join(storeDir, "block-0"))
+	require.NoError(t, err)
+	defer fp.Close()
+
+	for _, v := range versions {
+		cs := &iavl.ChangeSet{Pairs: []*iavl.KVPair{
+			{Key: []byte("key"), Value: []byte("value")},
+		}}
+		require.NoError(t, WriteChangeSet(fp, v, cs))
+	}
+}
+
+// TestVerifyOneStoreBumpsVersionOnGaps reproduces the version skew bug: the live path
+// (memiavl.MultiTree.SaveVersion) bumps every store's tree version on every block, regardless of
+// whether that store had any writes. verifyOneStore must match that behavior instead of only
+// bumping the version on versions where this store's changeset happens to have an entry.
+func TestVerifyOneStoreBumpsVersionOnGaps(t *testing.T) {
+	dir := t.TempDir()
+
+	// "foo" only changed at versions 1 and 3, skipping version 2 entirely - as would happen for
+	// a store that had no writes in block 2.
+	writeStoreChangeSet(t, dir, "foo", []int64{1, 3})
+
+	tree := memiavl.New(0)
+	storeInfo, err := verifyOneStore(tree, "foo", dir, "", 3)
+	require.NoError(t, err)
+	require.NotNil(t, storeInfo)
+
+	// without the fix, the tree would only be bumped to version 2 (one SaveVersion call per
+	// changeset entry) and IterateChangeSets would fail with "version don't match: 2 != 3".
+	require.Equal(t, int64(3), tree.Version())
+	require.Equal(t, int64(3), storeInfo.CommitId.Version)
+}
+
+// TestVerifyOneStoreCatchesUpToTargetVersion checks that a store with no further changesets still
+// gets its tree version bumped up to the target version, matching every other store that keeps
+// advancing on every block in the live path.
+func TestVerifyOneStoreCatchesUpToTargetVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	writeStoreChangeSet(t, dir, "foo", []int64{1})
+
+	tree := memiavl.New(0)
+	storeInfo, err := verifyOneStore(tree, "foo", dir, "", 5)
+	require.NoError(t, err)
+	require.NotNil(t, storeInfo)
+
+	require.Equal(t, int64(5), tree.Version())
+	require.Equal(t, int64(5), storeInfo.CommitId.Version)
 }

--- a/versiondb/client/verify_test.go
+++ b/versiondb/client/verify_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/cosmos/iavl"
-	"github.com/stretchr/testify/require"
 
 	"github.com/crypto-org-chain/cronos-store/memiavl"
+	"github.com/stretchr/testify/require"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 )

--- a/versiondb/client/verify_test.go
+++ b/versiondb/client/verify_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/cosmos/iavl"
-
 	"github.com/crypto-org-chain/cronos-store/memiavl"
 	"github.com/stretchr/testify/require"
 

--- a/versiondb/client/verify_test.go
+++ b/versiondb/client/verify_test.go
@@ -25,9 +25,6 @@ func TestBuildCommitInfoUsesVersionParam(t *testing.T) {
 	require.Equal(t, "a", ci.StoreInfos[0].Name, "storeInfos should be sorted by name")
 }
 
-// writeStoreChangeSet writes a single change set file for `store` containing entries only for the
-// given versions (mimicking a real dump, where a store's changeset file only records the versions
-// where that specific store changed).
 func writeStoreChangeSet(t *testing.T, changeSetDir, store string, versions []int64) {
 	t.Helper()
 
@@ -46,10 +43,6 @@ func writeStoreChangeSet(t *testing.T, changeSetDir, store string, versions []in
 	}
 }
 
-// TestVerifyOneStoreBumpsVersionOnGaps reproduces the version skew bug: the live path
-// (memiavl.MultiTree.SaveVersion) bumps every store's tree version on every block, regardless of
-// whether that store had any writes. verifyOneStore must match that behavior instead of only
-// bumping the version on versions where this store's changeset happens to have an entry.
 func TestVerifyOneStoreBumpsVersionOnGaps(t *testing.T) {
 	dir := t.TempDir()
 
@@ -62,15 +55,10 @@ func TestVerifyOneStoreBumpsVersionOnGaps(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, storeInfo)
 
-	// without the fix, the tree would only be bumped to version 2 (one SaveVersion call per
-	// changeset entry) and IterateChangeSets would fail with "version don't match: 2 != 3".
 	require.Equal(t, int64(3), tree.Version())
 	require.Equal(t, int64(3), storeInfo.CommitId.Version)
 }
 
-// TestVerifyOneStoreCatchesUpToTargetVersion checks that a store with no further changesets still
-// gets its tree version bumped up to the target version, matching every other store that keeps
-// advancing on every block in the live path.
 func TestVerifyOneStoreCatchesUpToTargetVersion(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## What

`versiondb/client/verify.go`'s `verifyOneStore` now advances every store's memiavl tree version through gaps with no-op `SaveVersion` calls, both across changeset gaps and after a store's last changeset up to the target version.

## Issue

`verifyOneStore` only called `tree.SaveVersion()` on versions where that store's own changeset file had an entry. The live path (`MultiTree.SaveVersion`) bumps every tree's version on every block regardless of whether that store had writes, since version numbers get hashed into tree nodes.

This meant a `--save-snapshot` bootstrap could produce per-store tree versions skewed from what live replay would produce. App hash matches at the bootstrap height, but diverges on the first block that writes to a store that was "lagging" during bootstrap but not during live replay.

## Solution

- Added a helper that repeatedly calls `tree.SaveVersion(false)` until a tree reaches a target version.
- Before applying a changeset at version N, advance the tree through any skipped versions up to N-1.
- After a store's last changeset, advance it up to the overall target version so every store ends up at the same version, matching live semantics.

## Test

- `TestVerifyOneStoreBumpsVersionOnGaps`: a store's changeset skips a version; asserts the tree still reaches the later version instead of hitting the existing "version don't match" guard.
- `TestVerifyOneStoreCatchesUpToTargetVersion`: a store's last changeset is well before the target version; asserts the tree still catches up.
- `go build ./...` and `go test ./...` pass for the affected modules.