### PR TITLE
fix(memiavl): reconcile lastCommitInfo against loaded trees on clean restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#91](https://github.com/crypto-org-chain/cronos-store/pull/91) fix(memiavl): reconcile lastCommitInfo against loaded trees on clean restart
 - [#76](https://github.com/crypto-org-chain/cronos-store/pull/76) fix(store): validate memiavl tree membership on load.
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.

--- a/memiavl/multitree.go
+++ b/memiavl/multitree.go
@@ -113,10 +113,7 @@ func LoadMultiTree(dir string, zeroCopy bool, cacheSize int, chainId string) (*M
 	// overflow checked in `readMetadata`.
 	mtree.setInitialVersion(uint32(metadata.InitialVersion))
 
-	// Verify metadata commit info matches the trees we actually loaded. Use
-	// each tree's own loaded version as ground truth, not the metadata's -
-	// otherwise a corrupted metadata.CommitInfo.Version would be fed back
-	// into buildCommitInfo and trivially match itself.
+	// Verify metadata commit info matches the trees we actually loaded.
 	actualVersion := metadata.CommitInfo.Version
 	if len(trees) > 0 {
 		actualVersion = trees[0].Version()
@@ -334,13 +331,6 @@ func (t *MultiTree) UpdateCommitInfo() {
 	t.lastCommitInfo = *t.buildCommitInfo(t.lastCommitInfo.Version)
 }
 
-// commitInfoEqual reports whether two commit infos are identical, returning
-// a descriptive error on the first mismatch found. Both `trusted` and
-// `actual` are expected to have their `StoreInfos` ordered by store name,
-// which holds for both the on-disk metadata (written from a `buildCommitInfo`
-// result) and freshly rebuilt commit infos, since trees are always kept
-// sorted by name (see `slices.Sort(treeNames)` in `LoadMultiTree`). If that
-// invariant ever breaks, this comparison would produce false mismatches.
 func commitInfoEqual(trusted, actual *CommitInfo) error {
 	if trusted.Version != actual.Version {
 		return fmt.Errorf("version mismatch: trusted=%d actual=%d", trusted.Version, actual.Version)

--- a/memiavl/multitree.go
+++ b/memiavl/multitree.go
@@ -113,14 +113,15 @@ func LoadMultiTree(dir string, zeroCopy bool, cacheSize int, chainId string) (*M
 	// overflow checked in `readMetadata`.
 	mtree.setInitialVersion(uint32(metadata.InitialVersion))
 
-	// The on-disk metadata is trusted blindly here, but `trees` were just
-	// rebuilt independently from `os.ReadDir`. If there's no pending WAL to
-	// replay, `CatchupWAL` returns early and never calls `UpdateCommitInfo`,
-	// so a stale or corrupted metadata file (e.g. from a torn write or a
-	// stray snapshot directory) would otherwise go undetected and get
-	// trusted as the app hash. Verify it matches what the loaded trees
-	// actually hash to before trusting it.
-	actual := mtree.buildCommitInfo(metadata.CommitInfo.Version)
+	// Verify metadata commit info matches the trees we actually loaded. Use
+	// each tree's own loaded version as ground truth, not the metadata's -
+	// otherwise a corrupted metadata.CommitInfo.Version would be fed back
+	// into buildCommitInfo and trivially match itself.
+	actualVersion := metadata.CommitInfo.Version
+	if len(trees) > 0 {
+		actualVersion = trees[0].Tree.Version()
+	}
+	actual := mtree.buildCommitInfo(actualVersion)
 	if err := commitInfoEqual(metadata.CommitInfo, actual); err != nil {
 		return nil, fmt.Errorf("snapshot metadata commit info does not match loaded trees: %w", err)
 	}
@@ -338,7 +339,8 @@ func (t *MultiTree) UpdateCommitInfo() {
 // `actual` are expected to have their `StoreInfos` ordered by store name,
 // which holds for both the on-disk metadata (written from a `buildCommitInfo`
 // result) and freshly rebuilt commit infos, since trees are always kept
-// sorted by name.
+// sorted by name (see `slices.Sort(treeNames)` in `LoadMultiTree`). If that
+// invariant ever breaks, this comparison would produce false mismatches.
 func commitInfoEqual(trusted, actual *CommitInfo) error {
 	if trusted.Version != actual.Version {
 		return fmt.Errorf("version mismatch: trusted=%d actual=%d", trusted.Version, actual.Version)

--- a/memiavl/multitree.go
+++ b/memiavl/multitree.go
@@ -119,7 +119,7 @@ func LoadMultiTree(dir string, zeroCopy bool, cacheSize int, chainId string) (*M
 	// into buildCommitInfo and trivially match itself.
 	actualVersion := metadata.CommitInfo.Version
 	if len(trees) > 0 {
-		actualVersion = trees[0].Tree.Version()
+		actualVersion = trees[0].Version()
 	}
 	actual := mtree.buildCommitInfo(actualVersion)
 	if err := commitInfoEqual(metadata.CommitInfo, actual); err != nil {

--- a/memiavl/multitree.go
+++ b/memiavl/multitree.go
@@ -1,6 +1,7 @@
 package memiavl
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -111,6 +112,18 @@ func LoadMultiTree(dir string, zeroCopy bool, cacheSize int, chainId string) (*M
 	// initial version is nesserary for wal index conversion,
 	// overflow checked in `readMetadata`.
 	mtree.setInitialVersion(uint32(metadata.InitialVersion))
+
+	// The on-disk metadata is trusted blindly here, but `trees` were just
+	// rebuilt independently from `os.ReadDir`. If there's no pending WAL to
+	// replay, `CatchupWAL` returns early and never calls `UpdateCommitInfo`,
+	// so a stale or corrupted metadata file (e.g. from a torn write or a
+	// stray snapshot directory) would otherwise go undetected and get
+	// trusted as the app hash. Verify it matches what the loaded trees
+	// actually hash to before trusting it.
+	actual := mtree.buildCommitInfo(metadata.CommitInfo.Version)
+	if err := commitInfoEqual(metadata.CommitInfo, actual); err != nil {
+		return nil, fmt.Errorf("snapshot metadata commit info does not match loaded trees: %w", err)
+	}
 	return mtree, nil
 }
 
@@ -318,6 +331,34 @@ func (t *MultiTree) buildCommitInfo(version int64) *CommitInfo {
 // it's needed if `updateCommitInfo` is set to `false` in `ApplyChangeSet`.
 func (t *MultiTree) UpdateCommitInfo() {
 	t.lastCommitInfo = *t.buildCommitInfo(t.lastCommitInfo.Version)
+}
+
+// commitInfoEqual reports whether two commit infos are identical, returning
+// a descriptive error on the first mismatch found. Both `trusted` and
+// `actual` are expected to have their `StoreInfos` ordered by store name,
+// which holds for both the on-disk metadata (written from a `buildCommitInfo`
+// result) and freshly rebuilt commit infos, since trees are always kept
+// sorted by name.
+func commitInfoEqual(trusted, actual *CommitInfo) error {
+	if trusted.Version != actual.Version {
+		return fmt.Errorf("version mismatch: trusted=%d actual=%d", trusted.Version, actual.Version)
+	}
+	if len(trusted.StoreInfos) != len(actual.StoreInfos) {
+		return fmt.Errorf("store count mismatch: trusted=%d actual=%d", len(trusted.StoreInfos), len(actual.StoreInfos))
+	}
+	for i, want := range trusted.StoreInfos {
+		got := actual.StoreInfos[i]
+		if want.Name != got.Name {
+			return fmt.Errorf("store name mismatch at index %d: trusted=%s actual=%s", i, want.Name, got.Name)
+		}
+		if want.CommitId.Version != got.CommitId.Version {
+			return fmt.Errorf("store %s version mismatch: trusted=%d actual=%d", want.Name, want.CommitId.Version, got.CommitId.Version)
+		}
+		if !bytes.Equal(want.CommitId.Hash, got.CommitId.Hash) {
+			return fmt.Errorf("store %s hash mismatch: trusted=%x actual=%x", want.Name, want.CommitId.Hash, got.CommitId.Hash)
+		}
+	}
+	return nil
 }
 
 // CatchupWAL replay the new entries in the WAL on the tree to catch-up to the target or latest version.

--- a/memiavl/multitree_test.go
+++ b/memiavl/multitree_test.go
@@ -389,12 +389,6 @@ func TestMultiTreeWorkerPoolQueuedTasksShouldNotStart(t *testing.T) {
 	}
 }
 
-// TestLoadMultiTreeRejectsStaleMetadata reproduces a clean restart where the
-// on-disk `__metadata` file's commit info no longer matches what the trees
-// actually loaded from disk would hash to (e.g. a torn write, or a stray/
-// stale snapshot directory). There's no pending WAL entry to replay, so
-// `CatchupWAL`'s `UpdateCommitInfo` call never happens on this path; `Load`
-// itself must catch the mismatch instead of silently trusting the metadata.
 func TestLoadMultiTreeRejectsStaleMetadata(t *testing.T) {
 	const wantErrMismatch = "snapshot metadata commit info does not match loaded trees"
 

--- a/memiavl/multitree_test.go
+++ b/memiavl/multitree_test.go
@@ -396,6 +396,8 @@ func TestMultiTreeWorkerPoolQueuedTasksShouldNotStart(t *testing.T) {
 // `CatchupWAL`'s `UpdateCommitInfo` call never happens on this path; `Load`
 // itself must catch the mismatch instead of silently trusting the metadata.
 func TestLoadMultiTreeRejectsStaleMetadata(t *testing.T) {
+	const wantErrMismatch = "snapshot metadata commit info does not match loaded trees"
+
 	cases := []struct {
 		name    string
 		corrupt func(ci *CommitInfo)
@@ -406,21 +408,21 @@ func TestLoadMultiTreeRejectsStaleMetadata(t *testing.T) {
 			corrupt: func(ci *CommitInfo) {
 				ci.StoreInfos[0].CommitId.Hash = []byte("bogus-hash-from-torn-write")
 			},
-			wantErr: "snapshot metadata commit info does not match loaded trees",
+			wantErr: wantErrMismatch,
 		},
 		{
 			name: "version mismatch",
 			corrupt: func(ci *CommitInfo) {
 				ci.Version++
 			},
-			wantErr: "snapshot metadata commit info does not match loaded trees",
+			wantErr: wantErrMismatch,
 		},
 		{
 			name: "store count mismatch",
 			corrupt: func(ci *CommitInfo) {
 				ci.StoreInfos = ci.StoreInfos[:len(ci.StoreInfos)-1]
 			},
-			wantErr: "snapshot metadata commit info does not match loaded trees",
+			wantErr: wantErrMismatch,
 		},
 	}
 

--- a/memiavl/multitree_test.go
+++ b/memiavl/multitree_test.go
@@ -480,4 +480,3 @@ func TestLoadMultiTreeRejectsStaleMetadata(t *testing.T) {
 		})
 	}
 }
-

--- a/memiavl/multitree_test.go
+++ b/memiavl/multitree_test.go
@@ -396,53 +396,86 @@ func TestMultiTreeWorkerPoolQueuedTasksShouldNotStart(t *testing.T) {
 // `CatchupWAL`'s `UpdateCommitInfo` call never happens on this path; `Load`
 // itself must catch the mismatch instead of silently trusting the metadata.
 func TestLoadMultiTreeRejectsStaleMetadata(t *testing.T) {
-	mtree := NewEmptyMultiTree(0, 0, TestAppChainID)
-
-	stores := []string{store1Name, store2Name}
-	var upgrades []*TreeNameUpgrade
-	for _, name := range stores {
-		upgrades = append(upgrades, &TreeNameUpgrade{Name: name})
+	cases := []struct {
+		name    string
+		corrupt func(ci *CommitInfo)
+		wantErr string
+	}{
+		{
+			name: "hash mismatch",
+			corrupt: func(ci *CommitInfo) {
+				ci.StoreInfos[0].CommitId.Hash = []byte("bogus-hash-from-torn-write")
+			},
+			wantErr: "snapshot metadata commit info does not match loaded trees",
+		},
+		{
+			name: "version mismatch",
+			corrupt: func(ci *CommitInfo) {
+				ci.Version++
+			},
+			wantErr: "snapshot metadata commit info does not match loaded trees",
+		},
+		{
+			name: "store count mismatch",
+			corrupt: func(ci *CommitInfo) {
+				ci.StoreInfos = ci.StoreInfos[:len(ci.StoreInfos)-1]
+			},
+			wantErr: "snapshot metadata commit info does not match loaded trees",
+		},
 	}
-	require.NoError(t, mtree.ApplyUpgrades(upgrades))
 
-	for _, storeName := range stores {
-		tree := mtree.TreeByName(storeName)
-		require.NotNil(t, tree)
-		tree.set([]byte("key"), []byte("value"))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mtree := NewEmptyMultiTree(0, 0, TestAppChainID)
+
+			stores := []string{store1Name, store2Name}
+			var upgrades []*TreeNameUpgrade
+			for _, name := range stores {
+				upgrades = append(upgrades, &TreeNameUpgrade{Name: name})
+			}
+			require.NoError(t, mtree.ApplyUpgrades(upgrades))
+
+			for _, storeName := range stores {
+				tree := mtree.TreeByName(storeName)
+				require.NotNil(t, tree)
+				tree.set([]byte("key"), []byte("value"))
+			}
+
+			_, err := mtree.SaveVersion(true)
+			require.NoError(t, err)
+
+			pool := pond.New(2, 10)
+			defer pool.StopAndWait()
+
+			snapshotDir := t.TempDir()
+			require.NoError(t, mtree.WriteSnapshot(snapshotDir, pool))
+
+			// Sanity check: loading the untouched snapshot succeeds.
+			mtreeOK, err := LoadMultiTree(snapshotDir, false, 0, TestAppChainID)
+			require.NoError(t, err)
+			mtreeOK.Close()
+
+			// Corrupt the trusted metadata to no longer match the trees on disk,
+			// without touching the trees themselves or the WAL.
+			staleStoreInfos := make([]StoreInfo, len(mtree.lastCommitInfo.StoreInfos))
+			copy(staleStoreInfos, mtree.lastCommitInfo.StoreInfos)
+			staleCommitInfo := CommitInfo{
+				Version:    mtree.lastCommitInfo.Version,
+				StoreInfos: staleStoreInfos,
+			}
+			tc.corrupt(&staleCommitInfo)
+			staleMetadata := MultiTreeMetadata{
+				CommitInfo:     &staleCommitInfo,
+				InitialVersion: int64(mtree.initialVersion),
+			}
+			bz, err := staleMetadata.Marshal()
+			require.NoError(t, err)
+			require.NoError(t, WriteFileSync(filepath.Join(snapshotDir, MetadataFileName), bz))
+
+			_, err = LoadMultiTree(snapshotDir, false, 0, TestAppChainID)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
 	}
-
-	_, err := mtree.SaveVersion(true)
-	require.NoError(t, err)
-
-	pool := pond.New(2, 10)
-	defer pool.StopAndWait()
-
-	snapshotDir := t.TempDir()
-	require.NoError(t, mtree.WriteSnapshot(snapshotDir, pool))
-
-	// Sanity check: loading the untouched snapshot succeeds.
-	mtreeOK, err := LoadMultiTree(snapshotDir, false, 0, TestAppChainID)
-	require.NoError(t, err)
-	mtreeOK.Close()
-
-	// Corrupt the trusted metadata to no longer match the trees on disk,
-	// without touching the trees themselves or the WAL.
-	staleStoreInfos := make([]StoreInfo, len(mtree.lastCommitInfo.StoreInfos))
-	copy(staleStoreInfos, mtree.lastCommitInfo.StoreInfos)
-	staleStoreInfos[0].CommitId.Hash = []byte("bogus-hash-from-torn-write")
-	staleCommitInfo := CommitInfo{
-		Version:    mtree.lastCommitInfo.Version,
-		StoreInfos: staleStoreInfos,
-	}
-	staleMetadata := MultiTreeMetadata{
-		CommitInfo:     &staleCommitInfo,
-		InitialVersion: int64(mtree.initialVersion),
-	}
-	bz, err := staleMetadata.Marshal()
-	require.NoError(t, err)
-	require.NoError(t, WriteFileSync(filepath.Join(snapshotDir, MetadataFileName), bz))
-
-	_, err = LoadMultiTree(snapshotDir, false, 0, TestAppChainID)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "snapshot metadata commit info does not match loaded trees")
 }
+

--- a/memiavl/multitree_test.go
+++ b/memiavl/multitree_test.go
@@ -388,3 +388,61 @@ func TestMultiTreeWorkerPoolQueuedTasksShouldNotStart(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 	}
 }
+
+// TestLoadMultiTreeRejectsStaleMetadata reproduces a clean restart where the
+// on-disk `__metadata` file's commit info no longer matches what the trees
+// actually loaded from disk would hash to (e.g. a torn write, or a stray/
+// stale snapshot directory). There's no pending WAL entry to replay, so
+// `CatchupWAL`'s `UpdateCommitInfo` call never happens on this path; `Load`
+// itself must catch the mismatch instead of silently trusting the metadata.
+func TestLoadMultiTreeRejectsStaleMetadata(t *testing.T) {
+	mtree := NewEmptyMultiTree(0, 0, TestAppChainID)
+
+	stores := []string{store1Name, store2Name}
+	var upgrades []*TreeNameUpgrade
+	for _, name := range stores {
+		upgrades = append(upgrades, &TreeNameUpgrade{Name: name})
+	}
+	require.NoError(t, mtree.ApplyUpgrades(upgrades))
+
+	for _, storeName := range stores {
+		tree := mtree.TreeByName(storeName)
+		require.NotNil(t, tree)
+		tree.set([]byte("key"), []byte("value"))
+	}
+
+	_, err := mtree.SaveVersion(true)
+	require.NoError(t, err)
+
+	pool := pond.New(2, 10)
+	defer pool.StopAndWait()
+
+	snapshotDir := t.TempDir()
+	require.NoError(t, mtree.WriteSnapshot(snapshotDir, pool))
+
+	// Sanity check: loading the untouched snapshot succeeds.
+	mtreeOK, err := LoadMultiTree(snapshotDir, false, 0, TestAppChainID)
+	require.NoError(t, err)
+	mtreeOK.Close()
+
+	// Corrupt the trusted metadata to no longer match the trees on disk,
+	// without touching the trees themselves or the WAL.
+	staleStoreInfos := make([]StoreInfo, len(mtree.lastCommitInfo.StoreInfos))
+	copy(staleStoreInfos, mtree.lastCommitInfo.StoreInfos)
+	staleStoreInfos[0].CommitId.Hash = []byte("bogus-hash-from-torn-write")
+	staleCommitInfo := CommitInfo{
+		Version:    mtree.lastCommitInfo.Version,
+		StoreInfos: staleStoreInfos,
+	}
+	staleMetadata := MultiTreeMetadata{
+		CommitInfo:     &staleCommitInfo,
+		InitialVersion: int64(mtree.initialVersion),
+	}
+	bz, err := staleMetadata.Marshal()
+	require.NoError(t, err)
+	require.NoError(t, WriteFileSync(filepath.Join(snapshotDir, MetadataFileName), bz))
+
+	_, err = LoadMultiTree(snapshotDir, false, 0, TestAppChainID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "snapshot metadata commit info does not match loaded trees")
+}


### PR DESCRIPTION
## What

`LoadMultiTree` in `memiavl/multitree.go` now verifies the on-disk metadata's `CommitInfo` against the commit info actually produced by the loaded trees, and fails loudly on mismatch.

## Issue

`lastCommitInfo` was loaded verbatim from the metadata file, while `trees` were built independently from `os.ReadDir`. `CatchupWAL` only recomputes `lastCommitInfo` when there are WAL entries to replay. On a clean restart at the snapshot version, that's skipped entirely, so a stale or corrupted metadata file (torn write, stray directory) would be trusted with nothing catching the divergence — and that divergence surfaces as an app-hash mismatch later.

## Solution

- After building the multitree from disk, compute the actual commit info from the loaded trees and compare it against the trusted metadata.
- On mismatch, return a descriptive error instead of silently trusting the metadata, following the same fail-loud pattern as `validateMemiAVLTreeMembership` (#76).
- Confirmed all callers of `LoadMultiTree` already propagate its errors correctly, so no caller changes were needed.

## Test

- `TestLoadMultiTreeRejectsStaleMetadata`: writes a real snapshot, confirms it loads, then corrupts one store's hash in the on-disk metadata file (simulating a torn write) and asserts `LoadMultiTree` now returns an error.
- `go build ./...`, `go vet ./...`, and `go test ./memiavl/...` pass, including the pre-existing empty-tree round-trip test (rules out a false positive on empty stores).