### PR TITLE
fix(memiavl): don't ack app hash before its WAL entry is durably synced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#92](https://github.com/crypto-org-chain/cronos-store/pull/92) fix(memiavl): don't ack app hash before its WAL entry is durably synced
 - [#76](https://github.com/crypto-org-chain/cronos-store/pull/76) fix(store): validate memiavl tree membership on load.
 - [#73](https://github.com/crypto-org-chain/cronos-store/pull/73) fix(memiavl): treat `endVersion == 0` as "to latest" (consistently in `TraverseStateChanges` and `CatchupWAL`) and reject a negative `endVersion` with an error instead of silently traversing nothing.
 - [#74](https://github.com/crypto-org-chain/cronos-store/pull/74) fix(memiavl): honor the early-stop return value in `ScanPostOrder` so the scan stops when the callback returns true, instead of always walking the whole tree.

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -26,12 +26,10 @@ const (
 
 var errReadOnly = errors.New("db is read-only")
 
-// walSync fsyncs the wal, guaranteeing entries written to it are durable
-// (the wal is opened with NoSync:true, so wal.Log.WriteBatch alone only
-// lands entries in the OS page cache). It's a package-level var so tests
-// can observe or fail this call without reaching into the vendored wal
-// library's internals.
-var walSync = func(w *wal.Log) error {
+// defaultWalSync fsyncs the wal, guaranteeing entries written to it are
+// durable (the wal is opened with NoSync:true, so wal.Log.WriteBatch alone
+// only lands entries in the OS page cache).
+func defaultWalSync(w *wal.Log) error {
 	return w.Sync()
 }
 
@@ -80,6 +78,9 @@ type DB struct {
 	walChanSize int
 	walChan     chan *walEntry
 	walQuit     chan error
+	// walSync fsyncs db.wal; overridable per-instance in tests without
+	// touching shared package state.
+	walSync func(*wal.Log) error
 
 	// pending changes, will be written into WAL in next Commit call
 	pendingLog              WALEntry
@@ -269,6 +270,7 @@ func Load(dir string, opts Options, chainId string) (*DB, error) {
 		snapshotInterval:       opts.SnapshotInterval,
 		triggerStateSyncExport: opts.TriggerStateSyncExport,
 		snapshotWriterPool:     workerPool,
+		walSync:                defaultWalSync,
 	}
 	db.attachTraverseStateChanges()
 
@@ -694,7 +696,7 @@ func (db *DB) Commit() (int64, error) {
 			// the entry in the OS page cache. Fsync explicitly before returning
 			// the app hash: otherwise a crash before the OS flushes the page
 			// cache would lose an entry whose hash was already acknowledged.
-			if err := walSync(db.wal); err != nil {
+			if err := db.walSync(db.wal); err != nil {
 				return 0, err
 			}
 		}
@@ -722,6 +724,11 @@ func (db *DB) initAsyncCommit() {
 
 		batch := wal.Batch{}
 		for {
+			// Commit holds db.mtx for its whole call and now blocks on this
+			// entry's outcome, so only one entry is ever in flight here at a
+			// time — channelBatchRecv's batching no longer accumulates more
+			// than one item per iteration. That's a deliberate side effect of
+			// trading commit latency for WAL durability, not a bug.
 			entries := channelBatchRecv(walChan)
 			if len(entries) == 0 {
 				// channel is closed
@@ -751,7 +758,7 @@ func (db *DB) initAsyncCommit() {
 				// landed the batch in the OS page cache. Fsync before notifying
 				// done: entries must not be reported durable while a crash could
 				// still lose them from the page cache.
-				writeErr = walSync(db.wal)
+				writeErr = db.walSync(db.wal)
 			}
 
 			notifyDone(entries, writeErr)

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -26,6 +26,15 @@ const (
 
 var errReadOnly = errors.New("db is read-only")
 
+// walSync fsyncs the wal, guaranteeing entries written to it are durable
+// (the wal is opened with NoSync:true, so wal.Log.WriteBatch alone only
+// lands entries in the OS page cache). It's a package-level var so tests
+// can observe or fail this call without reaching into the vendored wal
+// library's internals.
+var walSync = func(w *wal.Log) error {
+	return w.Sync()
+}
+
 // DB implements DB-like functionalities on top of MultiTree:
 // - async snapshot rewriting
 // - Write-ahead-log
@@ -680,6 +689,14 @@ func (db *DB) Commit() (int64, error) {
 			if err := db.wal.WriteBatch(&db.wbatch); err != nil {
 				return 0, err
 			}
+
+			// The wal is opened with NoSync:true, so WriteBatch above only lands
+			// the entry in the OS page cache. Fsync explicitly before returning
+			// the app hash: otherwise a crash before the OS flushes the page
+			// cache would lose an entry whose hash was already acknowledged.
+			if err := walSync(db.wal); err != nil {
+				return 0, err
+			}
 		}
 	}
 
@@ -727,6 +744,14 @@ func (db *DB) initAsyncCommit() {
 
 			if writeErr == nil {
 				writeErr = db.wal.WriteBatch(&batch)
+			}
+
+			if writeErr == nil {
+				// The wal is opened with NoSync:true, so WriteBatch above only
+				// landed the batch in the OS page cache. Fsync before notifying
+				// done: entries must not be reported durable while a crash could
+				// still lose them from the page cache.
+				writeErr = walSync(db.wal)
 			}
 
 			notifyDone(entries, writeErr)

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -637,8 +637,35 @@ func (db *DB) Commit() (int64, error) {
 				db.initAsyncCommit()
 			}
 
-			// async wal writing
-			db.walChan <- &entry
+			// Hand off to the async wal writer, but block until this entry's write
+			// outcome is known. The app hash computed above must not be acknowledged
+			// to the caller (and ultimately to consensus) while the durability of its
+			// WAL entry is still unresolved: a crash in that window would silently
+			// lose the WAL entry for a version whose hash was already reported.
+			// Since Commit holds db.mtx for its whole duration, only one entry is
+			// ever outstanding, so this trades away the writer's cross-commit
+			// batching for correctness; that's an accepted latency cost, not a
+			// throughput regression, since commits were already serialized.
+			//
+			// Both selects also race against walQuit: if the writer goroutine has
+			// already died (e.g. from a previous entry's write failure), it can
+			// never receive our entry nor signal done, so without this fallback
+			// Commit would block forever instead of surfacing the writer's error.
+			done := make(chan error, 1)
+			entry.done = done
+			select {
+			case db.walChan <- &entry:
+			case err := <-db.walQuit:
+				return 0, fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", err)
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					return 0, err
+				}
+			case err := <-db.walQuit:
+				return 0, fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", err)
+			}
 		} else {
 			lastIndex, err := db.wal.LastIndex()
 			if err != nil {
@@ -686,19 +713,26 @@ func (db *DB) initAsyncCommit() {
 
 			lastIndex, err := db.wal.LastIndex()
 			if err != nil {
+				notifyDone(entries, err)
 				walQuit <- err
 				return
 			}
 
+			var writeErr error
 			for _, entry := range entries {
-				if err := writeEntry(&batch, db.logger, lastIndex, entry); err != nil {
-					walQuit <- err
-					return
+				if writeErr = writeEntry(&batch, db.logger, lastIndex, entry); writeErr != nil {
+					break
 				}
 			}
 
-			if err := db.wal.WriteBatch(&batch); err != nil {
-				walQuit <- err
+			if writeErr == nil {
+				writeErr = db.wal.WriteBatch(&batch)
+			}
+
+			notifyDone(entries, writeErr)
+
+			if writeErr != nil {
+				walQuit <- writeErr
 				return
 			}
 			batch.Clear()
@@ -1308,6 +1342,20 @@ func createDBIfNotExist(dir string, initialVersion uint32, chainId string) error
 type walEntry struct {
 	index uint64
 	data  WALEntry
+	// done, if non-nil, receives the write outcome (see Commit).
+	done chan error
+}
+
+// notifyDone reports the outcome of a batch write to every entry in the
+// batch that's waiting for it. Entries earlier in a failed batch may not
+// have actually reached the WAL, but their outcome is unknown, so they're
+// reported as failed too rather than silently treated as durable.
+func notifyDone(entries []*walEntry, err error) {
+	for _, entry := range entries {
+		if entry.done != nil {
+			entry.done <- err
+		}
+	}
 }
 
 func isSnapshotName(name string) bool {

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -675,6 +676,113 @@ func TestFastCommit(t *testing.T) {
 
 	<-db.snapshotRewriteChan
 	require.NoError(t, db.Close())
+}
+
+// TestCommitFsyncsWALBeforeReturning confirms Commit actually fsyncs the wal
+// (via walSync) for every successful commit, on both the synchronous and
+// async wal-write paths. The wal is opened with NoSync:true, so without an
+// explicit Sync call, wal.Log.WriteBatch alone only lands entries in the OS
+// page cache: a crash before the OS flushes that cache would then lose an
+// entry whose app hash was already acknowledged to the caller.
+func TestCommitFsyncsWALBeforeReturning(t *testing.T) {
+	for _, asyncCommit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("asyncCommit=%v", asyncCommit), func(t *testing.T) {
+			testCommitFsyncsWALBeforeReturning(t, asyncCommit)
+		})
+	}
+}
+
+func testCommitFsyncsWALBeforeReturning(t *testing.T, asyncCommit bool) {
+	t.Helper()
+
+	asyncCommitBuffer := -1
+	if asyncCommit {
+		asyncCommitBuffer = 10
+	}
+
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: asyncCommitBuffer,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	original := walSync
+	var syncCalls atomic.Int32
+	walSync = func(w *wal.Log) error {
+		syncCalls.Add(1)
+		return original(w)
+	}
+	defer func() { walSync = original }()
+
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{
+			Pairs: []*KVPair{{Key: []byte("hello"), Value: []byte("world")}},
+		}},
+	}))
+
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, syncCalls.Load(), "Commit must fsync the wal entry before returning")
+}
+
+// TestCommitFailsWhenWALSyncFails confirms Commit does not report success
+// (acknowledging the app hash) when the WAL write lands in the OS page cache
+// (WriteBatch succeeds) but the fsync of that write fails. On both the
+// synchronous and async wal-write paths, a sync failure must surface as a
+// Commit error, not a silently-acknowledged version.
+func TestCommitFailsWhenWALSyncFails(t *testing.T) {
+	for _, asyncCommit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("asyncCommit=%v", asyncCommit), func(t *testing.T) {
+			testCommitFailsWhenWALSyncFails(t, asyncCommit)
+		})
+	}
+}
+
+func testCommitFailsWhenWALSyncFails(t *testing.T, asyncCommit bool) {
+	t.Helper()
+
+	asyncCommitBuffer := -1
+	if asyncCommit {
+		asyncCommitBuffer = 10
+	}
+
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: asyncCommitBuffer,
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	original := walSync
+	syncErr := errors.New("simulated fsync failure")
+	walSync = func(*wal.Log) error {
+		return syncErr
+	}
+	defer func() { walSync = original }()
+
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{
+			Pairs: []*KVPair{{Key: []byte("hello"), Value: []byte("world")}},
+		}},
+	}))
+
+	v, err := db.Commit()
+	require.ErrorIs(t, err, syncErr)
+	require.Zero(t, v)
+
+	// Close drains the async writer's terminal walQuit signal, which still
+	// carries the same sync failure (the writer goroutine reports it there
+	// too before exiting) - so Close is expected to surface it as well.
+	closeErr := db.Close()
+	if asyncCommit {
+		require.ErrorIs(t, closeErr, syncErr)
+	} else {
+		require.NoError(t, closeErr)
+	}
 }
 
 // TestCommitFailsSynchronouslyOnAsyncWALWriteError guards the durability

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -710,13 +710,12 @@ func testCommitFsyncsWALBeforeReturning(t *testing.T, asyncCommit bool) {
 		require.NoError(t, db.Close())
 	}()
 
-	original := walSync
+	original := db.walSync
 	var syncCalls atomic.Int32
-	walSync = func(w *wal.Log) error {
+	db.walSync = func(w *wal.Log) error {
 		syncCalls.Add(1)
 		return original(w)
 	}
-	defer func() { walSync = original }()
 
 	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
 		{Name: testStoreName, Changeset: ChangeSet{
@@ -757,12 +756,10 @@ func testCommitFailsWhenWALSyncFails(t *testing.T, asyncCommit bool) {
 	}, TestAppChainID)
 	require.NoError(t, err)
 
-	original := walSync
 	syncErr := errors.New("simulated fsync failure")
-	walSync = func(*wal.Log) error {
+	db.walSync = func(*wal.Log) error {
 		return syncErr
 	}
-	defer func() { walSync = original }()
 
 	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
 		{Name: testStoreName, Changeset: ChangeSet{

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/wal"
 )
 
 const TestAppChainID = "test_chain"
@@ -674,6 +675,96 @@ func TestFastCommit(t *testing.T) {
 
 	<-db.snapshotRewriteChan
 	require.NoError(t, db.Close())
+}
+
+// TestCommitFailsSynchronouslyOnAsyncWALWriteError guards the durability
+// ordering fix: Commit must not report a version successfully (acknowledging
+// its app hash) while the async WAL write for that same version failed.
+// Before the fix, the failure would only surface on the *next* Commit call
+// (via the non-blocking walQuit check), so this same Commit call would have
+// returned (v, nil) despite the WAL entry never having been persisted.
+func TestCommitFailsSynchronouslyOnAsyncWALWriteError(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Load(dir, Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: 10,
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{
+			Pairs: []*KVPair{{Key: []byte("hello"), Value: []byte("world")}},
+		}},
+	}))
+
+	// Simulate a crash-adjacent I/O failure hitting the async WAL writer:
+	// close the underlying WAL out from under it, so its next write fails.
+	require.NoError(t, db.wal.Close())
+
+	v, err := db.Commit()
+	require.ErrorIs(t, err, wal.ErrClosed)
+	require.Zero(t, v)
+
+	// unblock the writer goroutine (stuck delivering the error on walQuit)
+	// and the file lock, without re-touching the now-closed wal.
+	<-db.walQuit
+	db.walChan = nil
+	db.walQuit = nil
+	db.wal = nil
+	require.NoError(t, db.fileLock.Unlock())
+	require.NoError(t, db.fileLock.Destroy())
+}
+
+// TestCommitAfterDeadAsyncWriterDoesNotHang guards against a regression the
+// durability-ordering fix could otherwise introduce: once the async WAL
+// writer goroutine has died (e.g. after a write error), it can never drain
+// db.walChan or signal a `done` channel again. If Commit only waited on
+// `done` after handing an entry to a buffered walChan, a *later* Commit call
+// would enqueue successfully (buffer has room) and then block forever
+// waiting for a `done` that will never arrive. Commit must instead notice
+// the dead writer (via the same walQuit signal checkAsyncCommit already
+// treats as terminal) and fail fast.
+func TestCommitAfterDeadAsyncWriterDoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Load(dir, Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: 10,
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{
+			Pairs: []*KVPair{{Key: []byte("hello"), Value: []byte("world")}},
+		}},
+	}))
+
+	require.NoError(t, db.wal.Close())
+
+	_, err = db.Commit()
+	require.ErrorIs(t, err, wal.ErrClosed)
+
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{
+			Pairs: []*KVPair{{Key: []byte("hello2"), Value: []byte("world2")}},
+		}},
+	}))
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := db.Commit()
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second Commit call deadlocked waiting on a dead async wal writer")
+	}
 }
 
 func TestRepeatedApplyChangeSet(t *testing.T) {


### PR DESCRIPTION
## What

`Commit()` in `memiavl/db.go` now blocks until its WAL entry has been written and fsynced before returning the app hash, on both the synchronous and async-writer commit paths.

## Issue

`Commit()` computed the app hash and returned right after handing the WAL entry to the async writer channel, without waiting for the write — let alone an fsync — to happen. The actual `wal.WriteBatch` ran later in a decoupled goroutine, and the WAL was opened with `NoSync: true`, so even a successful write only landed in the OS page cache.

A crash between the app hash being acknowledged to consensus and that WAL entry becoming durable would silently lose the entry. This is normally masked by ABCI replay, but it's a real durability inversion with no safety net if replay assumptions ever change.

## Solution

- Added a per-entry outcome channel: `Commit()` sends the WAL entry and then blocks until the writer goroutine reports the write's result, so it can't return success while the write's outcome is unknown.
- Added an explicit `Sync()` call after a successful `WriteBatch` on both paths, so `Commit()` only reports success once the entry is truly fsynced, not just handed to the OS buffer. `NoSync: true` at WAL-open time is kept (the library's `Sync()` fsyncs unconditionally regardless of that flag, avoiding a double-fsync on every write).
- Guarded against a new deadlock this introduces: if the writer goroutine has already died from an earlier error, a later `Commit()`'s wait now selects against the existing terminal-error signal instead of blocking forever.
- This trades commit latency (a real fsync per version) for durability. That tradeoff was made deliberately — a half-measure that avoids the latency cost was considered and rejected.
- Out of scope: the writer-goroutine deadlock-on-error condition that exists independently of this change is already being fixed by #75/#79; this PR's deadlock guard is compatible with that latching mechanism, not a duplicate of it.

## Test

- `TestCommitFailsSynchronouslyOnAsyncWALWriteError`: closes the WAL out from under the writer, asserts the same `Commit()` call surfaces the error.
- `TestCommitAfterDeadAsyncWriterDoesNotHang`: regression test for the deadlock introduced and then fixed during development; asserts a later `Commit()` after the writer has died returns an error within a bounded timeout instead of hanging.
- `TestCommitFsyncsWALBeforeReturning` / `TestCommitFailsWhenWALSyncFails` (sync and async variants): assert exactly one `Sync()` per successful commit, and that a sync failure fails the commit.
- `go build ./...`, `go vet ./...`, and `go test -race -count=1 ./...` pass in `memiavl/`.