### PR TITLE
fix(memiavl,store): fix WAL durability-ack race, adopt lock-free query snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- [#102](https://github.com/crypto-org-chain/cronos-store/pull/102) fix(store): replace query-path mutex with lock-free snapshot
+- [#103](https://github.com/crypto-org-chain/cronos-store/pull/103) fix(memiavl,store): fix WAL durability-ack race, adopt lock-free query snapshot
 - [#86](https://github.com/crypto-org-chain/cronos-store/pull/86) fix(memiavl): close WAL after reading latest version in GetLatestVersion
 - [#82](https://github.com/crypto-org-chain/cronos-store/pull/82) fix(memiavl): close loaded MultiTree when CatchupWAL fails during snapshot rewrite
 - [#78](https://github.com/crypto-org-chain/cronos-store/pull/78) fix(store): return error for unknown store name in Query instead of panicking

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -26,6 +26,9 @@ const (
 
 var errReadOnly = errors.New("db is read-only")
 
+// method expression, not a call: `wal` is shadowed by a local variable at the assignment site.
+var defaultWalSync = (*wal.Log).Sync
+
 // DB implements DB-like functionalities on top of MultiTree:
 // - async snapshot rewriting
 // - Write-ahead-log
@@ -46,6 +49,9 @@ type DB struct {
 	MultiTree
 
 	// previous MultiTree generation, retained for one reload cycle (see reloadMultiTree).
+	// Copy() shares its source's mmap, so this is only safe while reload happens
+	// at most once per Commit -- true today since the only reload path is the
+	// serialized, much slower background snapshot rewrite.
 	retiredMultiTree *MultiTree
 
 	dir      string
@@ -71,8 +77,12 @@ type DB struct {
 	walChanSize int
 	walChan     chan *walEntry
 	walQuit     chan error
-	// latched async wal writer error; once set, every Commit fails with it.
+	// once set, every Commit fails with it.
 	walErr error
+	// walSync fsyncs db.wal; overridable per-instance in tests. The wal opens
+	// with NoSync, so WriteBatch alone leaves entries only in the page cache --
+	// a crash could then lose one already acknowledged by Commit.
+	walSync func(*wal.Log) error
 
 	// pending changes, will be written into WAL in next Commit call
 	pendingLog              WALEntry
@@ -262,6 +272,7 @@ func Load(dir string, opts Options, chainId string) (*DB, error) {
 		snapshotInterval:       opts.SnapshotInterval,
 		triggerStateSyncExport: opts.TriggerStateSyncExport,
 		snapshotWriterPool:     workerPool,
+		walSync:                defaultWalSync,
 	}
 	db.attachTraverseStateChanges()
 
@@ -479,7 +490,8 @@ func (db *DB) checkAsyncTasks() error {
 	)
 }
 
-// checkAsyncCommit check the quit signal of async wal writing
+// checkAsyncCommit returns any latched wal error, draining a pending
+// async-writer quit signal first.
 func (db *DB) checkAsyncCommit() error {
 	if db.walErr != nil {
 		return db.walErr
@@ -496,8 +508,17 @@ func (db *DB) checkAsyncCommit() error {
 // latchWalErr records a non-nil async wal writer error the first time it's seen
 // and returns the latched error. Callers hold db.mtx.
 func (db *DB) latchWalErr(err error) error {
+	if err == nil {
+		return db.walErr
+	}
+	return db.latchFatalErr(fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", err))
+}
+
+// latchFatalErr records the first fatal wal error so later commits are rejected
+// rather than proceeding on a tree now desynced from the wal. Callers hold db.mtx.
+func (db *DB) latchFatalErr(err error) error {
 	if err != nil && db.walErr == nil {
-		db.walErr = fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", err)
+		db.walErr = err
 	}
 	return db.walErr
 }
@@ -532,20 +553,20 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 			return nil
 		}
 
-		// wait for potential pending wal writings to finish, to make sure we catch up to latest state.
-		// in real world, block execution should be slower than wal writing, so this should not block for long.
-		for {
-			if err := db.checkAsyncCommit(); err != nil {
-				return errors.Join(err, result.mtree.Close())
-			}
-			committedVersion, err := db.CommittedVersion()
-			if err != nil {
-				return errors.Join(fmt.Errorf("get wal version failed: %w", err), result.mtree.Close())
-			}
-			if db.lastCommitInfo.Version == committedVersion {
-				break
-			}
-			time.Sleep(time.Nanosecond)
+		// Commit waits for its own wal entry, so the wal is already caught up to
+		// lastCommitInfo.Version; a mismatch is a bug, not something to retry for.
+		if err := db.checkAsyncCommit(); err != nil {
+			return errors.Join(err, result.mtree.Close())
+		}
+		committedVersion, err := db.CommittedVersion()
+		if err != nil {
+			return errors.Join(fmt.Errorf("get wal version failed: %w", err), result.mtree.Close())
+		}
+		if db.lastCommitInfo.Version != committedVersion {
+			return errors.Join(
+				fmt.Errorf("wal version %d does not match last commit version %d", committedVersion, db.lastCommitInfo.Version),
+				result.mtree.Close(),
+			)
 		}
 
 		// catchup the remaining wal
@@ -631,7 +652,11 @@ func (db *DB) pruneSnapshots() {
 	}()
 }
 
-// Commit wraps SaveVersion to bump the version and writes the pending changes into log files to persist on disk
+// Commit wraps SaveVersion to bump the version and writes the pending changes into log files to persist on disk.
+//
+// Any error returned is fatal: SaveVersion already advanced the in-memory tree
+// version, so a failed wal write leaves tree and wal disagreeing about the
+// latest version. Callers must crash rather than retry.
 func (db *DB) Commit() (int64, error) {
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
@@ -657,29 +682,33 @@ func (db *DB) Commit() (int64, error) {
 				db.initAsyncCommit()
 			}
 
-			// watch walQuit so a dead writer surfaces its error instead of
-			// blocking the send forever under db.mtx.
+			// entry.done carries the write outcome, so Commit can't return an app
+			// hash before its wal entry is synced. Also watch walQuit: a dead
+			// writer can never receive the entry nor signal done, so Commit would
+			// block forever instead of surfacing the writer's error.
+			done := make(chan error, 1)
+			entry.done = done
 			select {
 			case db.walChan <- &entry:
 			case err := <-db.walQuit:
-				if db.walErr = db.latchWalErr(err); db.walErr == nil {
-					db.walErr = errors.New("async wal writing goroutine quit unexpectedly")
+				if err == nil {
+					// closed without an exit reason, which shouldn't happen mid-Commit;
+					// force a non-nil error so this isn't reported as success.
+					err = errors.New("async wal writing goroutine quit unexpectedly")
 				}
-				return 0, db.walErr
+				return 0, db.latchWalErr(err)
+			}
+
+			// The writer accepted the entry, so done is guaranteed to fire (see
+			// notifyDone). This is the write's own error, not a writer crash, so
+			// skip latchWalErr's "goroutine quit" wrapping.
+			if err := <-done; err != nil {
+				return 0, db.latchFatalErr(err)
 			}
 		} else {
-			lastIndex, err := db.wal.LastIndex()
-			if err != nil {
-				return 0, err
-			}
-
 			db.wbatch.Clear()
-			if err := writeEntry(&db.wbatch, db.logger, lastIndex, &entry); err != nil {
-				return 0, err
-			}
-
-			if err := db.wal.WriteBatch(&db.wbatch); err != nil {
-				return 0, err
+			if err := db.writeAndSyncWAL(&db.wbatch, []*walEntry{&entry}); err != nil {
+				return 0, db.latchFatalErr(err)
 			}
 		}
 	}
@@ -713,21 +742,11 @@ func (db *DB) initAsyncCommit() {
 				break
 			}
 
-			lastIndex, err := db.wal.LastIndex()
-			if err != nil {
-				walQuit <- err
-				return
-			}
+			writeErr := db.writeAndSyncWAL(&batch, entries)
+			notifyDone(entries, writeErr)
 
-			for _, entry := range entries {
-				if err := writeEntry(&batch, db.logger, lastIndex, entry); err != nil {
-					walQuit <- err
-					return
-				}
-			}
-
-			if err := db.wal.WriteBatch(&batch); err != nil {
-				walQuit <- err
+			if writeErr != nil {
+				walQuit <- writeErr
 				return
 			}
 			batch.Clear()
@@ -775,6 +794,8 @@ func (db *DB) copy(cacheSize int) *DB {
 		dir:                db.dir,
 		snapshotWriterPool: db.snapshotWriterPool,
 	}
+	// avoids rescanning the snapshot dir on every EarliestVersion call.
+	cloned.earliestSnapshotCache.Store(db.earliestSnapshotCache.Load())
 	cloned.attachTraverseStateChanges()
 	return cloned
 }
@@ -1354,6 +1375,19 @@ func createDBIfNotExist(dir string, initialVersion uint32, chainId string) error
 type walEntry struct {
 	index uint64
 	data  WALEntry
+	// done, if non-nil, receives this entry's write outcome (see Commit).
+	done chan error
+}
+
+// notifyDone reports a batch write's outcome to every waiting entry. Entries
+// earlier in a failed batch may have reached the wal, but their outcome is
+// unknown, so they're reported as failed rather than assumed durable.
+func notifyDone(entries []*walEntry, err error) {
+	for _, entry := range entries {
+		if entry.done != nil {
+			entry.done <- err
+		}
+	}
 }
 
 func isSnapshotName(name string) bool {
@@ -1404,12 +1438,38 @@ func channelBatchRecv[T any](ch <-chan *T) []*T {
 	return result
 }
 
+func (db *DB) writeAndSyncWAL(batch *wal.Batch, entries []*walEntry) error {
+	lastIndex, err := db.wal.LastIndex()
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if err := writeEntry(batch, db.logger, lastIndex, entry); err != nil {
+			return err
+		}
+	}
+
+	if err := db.wal.WriteBatch(batch); err != nil {
+		return err
+	}
+	if err := db.walSync(db.wal); err != nil {
+		return err
+	}
+	// walSync only fsyncs the current segment file; a freshly cycled segment has
+	// no durable directory entry yet, so a crash could lose an entry whose app
+	// hash Commit already returned. Near-free when no metadata changed.
+	return fsyncDir(walPath(db.dir))
+}
+
 func writeEntry(batch *wal.Batch, logger Logger, lastIndex uint64, entry *walEntry) error {
 	bz, err := entry.data.Marshal()
 	if err != nil {
 		return err
 	}
 
+	// A version at or below lastIndex is already durable in the wal, so skipping
+	// it and reporting success is correct -- happens on replay after a restart.
 	if entry.index <= lastIndex {
 		logger.Error("commit old version idempotently", "lastIndex", lastIndex, "version", entry.index)
 	} else {

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -26,7 +26,6 @@ const (
 
 var errReadOnly = errors.New("db is read-only")
 
-// method expression, not a call: `wal` is shadowed by a local variable at the assignment site.
 var defaultWalSync = (*wal.Log).Sync
 
 // DB implements DB-like functionalities on top of MultiTree:
@@ -49,9 +48,6 @@ type DB struct {
 	MultiTree
 
 	// previous MultiTree generation, retained for one reload cycle (see reloadMultiTree).
-	// Copy() shares its source's mmap, so this is only safe while reload happens
-	// at most once per Commit -- true today since the only reload path is the
-	// serialized, much slower background snapshot rewrite.
 	retiredMultiTree *MultiTree
 
 	dir      string
@@ -79,9 +75,7 @@ type DB struct {
 	walQuit     chan error
 	// once set, every Commit fails with it.
 	walErr error
-	// walSync fsyncs db.wal; overridable per-instance in tests. The wal opens
-	// with NoSync, so WriteBatch alone leaves entries only in the page cache --
-	// a crash could then lose one already acknowledged by Commit.
+	// walSync fsyncs db.wal; overridable per-instance in tests.
 	walSync func(*wal.Log) error
 
 	// pending changes, will be written into WAL in next Commit call

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -26,7 +26,10 @@ const (
 
 var errReadOnly = errors.New("db is read-only")
 
-var defaultWalSync = (*wal.Log).Sync
+// errWALAhead signals that the wal is still ahead of the committed tree, an
+// expected condition while replaying after a restart at a lower target
+// version rather than an actual failure.
+var errWALAhead = errors.New("wal is ahead of the committed tree")
 
 // DB implements DB-like functionalities on top of MultiTree:
 // - async snapshot rewriting
@@ -92,6 +95,9 @@ type DB struct {
 	mtx sync.Mutex
 	// worker goroutine IdleTimeout = 5s
 	snapshotWriterPool *pond.WorkerPool
+	// ownsWriterPool is set only on DBs created by Load, which must stop the pool
+	// on Close; copies share the pool and must leave it running.
+	ownsWriterPool bool
 
 	// cached earliest snapshot version. Loaded lazily and refreshed by
 	// pruneSnapshots. Zero means "not cached"; readers should fall back to
@@ -100,6 +106,10 @@ type DB struct {
 
 	// reusable write batch
 	wbatch wal.Batch
+
+	// Test-only hook, nil in production: exposes the post-rewrite multitree, which
+	// is otherwise local to the rewrite goroutine, before its WAL catchup runs.
+	onCatchupMTreeLoaded func(*MultiTree)
 }
 
 type Options struct {
@@ -160,7 +170,7 @@ const (
 	SnapshotDirLen = len(SnapshotPrefix) + 20
 )
 
-func Load(dir string, opts Options, chainId string) (*DB, error) {
+func Load(dir string, opts Options, chainId string) (_ *DB, retErr error) {
 	if err := opts.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid options: %w", err)
 	}
@@ -175,7 +185,27 @@ func Load(dir string, opts Options, chainId string) (*DB, error) {
 	var (
 		err      error
 		fileLock FileLock
+		mtree    *MultiTree
+		walLog   *wal.Log
 	)
+	// The lock file, the trees' mmaps and the wal's fds transfer to the returned DB
+	// only once it's constructed; until then a bare `return nil, err` would hold all
+	// three for the process's lifetime, so a retried Load could never re-lock the dir.
+	ownershipMoved := false
+	defer func() {
+		if ownershipMoved {
+			return
+		}
+		if mtree != nil {
+			retErr = errors.Join(retErr, mtree.Close())
+		}
+		if walLog != nil {
+			retErr = errors.Join(retErr, walLog.Close())
+		}
+		if fileLock != nil {
+			retErr = errors.Join(retErr, fileLock.Unlock(), fileLock.Destroy())
+		}
+	}()
 	if !opts.ReadOnly {
 		fileLock, err = LockFile(filepath.Join(dir, LockFileName))
 		if err != nil {
@@ -199,19 +229,19 @@ func Load(dir string, opts Options, chainId string) (*DB, error) {
 	}
 
 	path := filepath.Join(dir, snapshot)
-	mtree, err := LoadMultiTree(path, opts.ZeroCopy, opts.CacheSize, chainId)
+	mtree, err = LoadMultiTree(path, opts.ZeroCopy, opts.CacheSize, chainId)
 	if err != nil {
 		return nil, err
 	}
 
-	wal, err := OpenWAL(walPath(dir), &wal.Options{NoCopy: true, NoSync: true})
+	walLog, err = OpenWAL(walPath(dir), &wal.Options{NoCopy: true, NoSync: true})
 	if err != nil {
 		return nil, err
 	}
 
 	if opts.TargetVersion == 0 || int64(opts.TargetVersion) > mtree.Version() {
-		if err := mtree.CatchupWAL(wal, int64(opts.TargetVersion)); err != nil {
-			return nil, errors.Join(err, wal.Close())
+		if err := mtree.CatchupWAL(walLog, int64(opts.TargetVersion)); err != nil {
+			return nil, err
 		}
 	}
 
@@ -231,7 +261,7 @@ func Load(dir string, opts Options, chainId string) (*DB, error) {
 
 		// truncate the WAL
 		opts.Logger.Info("truncate WAL from back", "version", opts.TargetVersion)
-		if err := wal.TruncateBack(walIndex(int64(opts.TargetVersion), mtree.initialVersion)); err != nil {
+		if err := walLog.TruncateBack(walIndex(int64(opts.TargetVersion), mtree.initialVersion)); err != nil {
 			return nil, fmt.Errorf("fail to truncate wal logs: %w", err)
 		}
 
@@ -260,14 +290,16 @@ func Load(dir string, opts Options, chainId string) (*DB, error) {
 		dir:                    dir,
 		fileLock:               fileLock,
 		readOnly:               opts.ReadOnly,
-		wal:                    wal,
+		wal:                    walLog,
 		walChanSize:            opts.AsyncCommitBuffer,
 		snapshotKeepRecent:     opts.SnapshotKeepRecent,
 		snapshotInterval:       opts.SnapshotInterval,
 		triggerStateSyncExport: opts.TriggerStateSyncExport,
 		snapshotWriterPool:     workerPool,
-		walSync:                defaultWalSync,
+		ownsWriterPool:         true,
+		walSync:                (*wal.Log).Sync,
 	}
+	ownershipMoved = true
 	db.attachTraverseStateChanges()
 
 	if !db.readOnly && db.Version() == 0 && len(opts.InitialStores) > 0 {
@@ -519,6 +551,17 @@ func (db *DB) latchFatalErr(err error) error {
 
 // CommittedVersion returns the latest version written in wal, or snapshot version if wal is empty.
 func (db *DB) CommittedVersion() (int64, error) {
+	db.mtx.Lock()
+	defer db.mtx.Unlock()
+
+	return db.committedVersion()
+}
+
+// committedVersion is CommittedVersion without the lock. Callers hold db.mtx.
+func (db *DB) committedVersion() (int64, error) {
+	if db.wal == nil {
+		return 0, fmt.Errorf("wal is not initialized")
+	}
 	lastIndex, err := db.wal.LastIndex()
 	if err != nil {
 		return 0, err
@@ -547,42 +590,72 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 			return nil
 		}
 
-		// Commit waits for its own wal entry, so the wal is already caught up to
-		// lastCommitInfo.Version; a mismatch is a bug, not something to retry for.
-		if err := db.checkAsyncCommit(); err != nil {
-			return errors.Join(err, result.mtree.Close())
-		}
-		committedVersion, err := db.CommittedVersion()
-		if err != nil {
-			return errors.Join(fmt.Errorf("get wal version failed: %w", err), result.mtree.Close())
-		}
-		if db.lastCommitInfo.Version != committedVersion {
-			return errors.Join(
-				fmt.Errorf("wal version %d does not match last commit version %d", committedVersion, db.lastCommitInfo.Version),
-				result.mtree.Close(),
-			)
-		}
-
-		// catchup the remaining wal
-		if err := result.mtree.CatchupWAL(db.wal, 0); err != nil {
-			return errors.Join(fmt.Errorf("final catchup failed: %w", err), result.mtree.Close())
-		}
-
-		// do the switch
-		if err := db.reloadMultiTree(result.mtree); err != nil {
-			return fmt.Errorf("switch multitree failed: %w", err)
-		}
-		db.logger.Info("switched to new snapshot", "version", db.MultiTree.Version())
-
-		db.pruneSnapshots()
-
-		// trigger state-sync snapshot export
-		if db.triggerStateSyncExport != nil {
-			db.triggerStateSyncExport(db.SnapshotVersion())
-		}
+		return db.adoptSnapshotRewrite(result.mtree)
 	default:
 	}
 
+	return nil
+}
+
+// adoptSnapshotRewrite installs a completed background snapshot rewrite, catching
+// it up to the last committed version first. It takes ownership of mtree: every
+// exit that doesn't reach reloadMultiTree releases the rewritten tree's mmap'd
+// snapshot, and reloadMultiTree takes over that responsibility once reached.
+func (db *DB) adoptSnapshotRewrite(mtree *MultiTree) (err error) {
+	reloadCalled := false
+	defer func() {
+		if !reloadCalled {
+			err = errors.Join(err, mtree.Close())
+		}
+	}()
+
+	// Commit waits for its own wal entry, so the wal can only be at or ahead of
+	// lastCommitInfo.Version by now; falling behind would be a bug.
+	if err := db.checkAsyncCommit(); err != nil {
+		return err
+	}
+	committedVersion, cerr := db.committedVersion()
+	if cerr != nil {
+		return fmt.Errorf("get wal version failed: %w", cerr)
+	}
+	if committedVersion < db.lastCommitInfo.Version {
+		return fmt.Errorf("wal version %d is behind last commit version %d", committedVersion, db.lastCommitInfo.Version)
+	}
+
+	// rewriteSnapshotBackground refuses to start while the wal is ahead of the
+	// tree, and a new commit advances the wal and lastCommitInfo together
+	// under db.mtx, so this branch should be unreachable in normal operation.
+	// It's a pure backstop against an overshoot that can't be rolled back:
+	// discard it rather than catch up (CatchupWAL would target a pruned index
+	// and error).
+	if mtree.Version() > db.lastCommitInfo.Version {
+		db.logger.Info("discarding snapshot rewrite ahead of committed version",
+			"rewrite", mtree.Version(), "committed", db.lastCommitInfo.Version)
+		return nil
+	}
+
+	if mtree.Version() < db.lastCommitInfo.Version {
+		if err := mtree.CatchupWAL(db.wal, db.lastCommitInfo.Version); err != nil {
+			return fmt.Errorf("final catchup failed: %w", err)
+		}
+	}
+	if mtree.Version() != db.lastCommitInfo.Version {
+		return fmt.Errorf("catchup landed on version %d, want %d", mtree.Version(), db.lastCommitInfo.Version)
+	}
+
+	// do the switch
+	reloadCalled = true
+	if err := db.reloadMultiTree(mtree); err != nil {
+		return fmt.Errorf("switch multitree failed: %w", err)
+	}
+	db.logger.Info("switched to new snapshot", "version", db.MultiTree.Version())
+
+	db.pruneSnapshots()
+
+	// trigger state-sync snapshot export
+	if db.triggerStateSyncExport != nil {
+		db.triggerStateSyncExport(db.SnapshotVersion())
+	}
 	return nil
 }
 
@@ -867,6 +940,10 @@ func (db *DB) rewriteIfApplicable(height int64) {
 	}
 
 	if err := db.rewriteSnapshotBackground(); err != nil {
+		if errors.Is(err, errWALAhead) {
+			db.logger.Info("skipping snapshot rewrite while replaying the wal", "err", err)
+			return
+		}
 		db.logger.Error("failed to rewrite snapshot in background", "err", err)
 	}
 }
@@ -894,6 +971,19 @@ func (db *DB) rewriteSnapshotBackground() error {
 		return errors.New("there's another ongoing snapshot rewriting process")
 	}
 
+	// A wal ahead of the tree means the app is still replaying versions it had
+	// committed before a restart at a lower target version. Starting a rewrite now
+	// would write a snapshot and replay the rest of the wal into a second tree, only
+	// to be discarded by checkBackgroundSnapshotRewrite for overshooting the
+	// committed version. Wait for the replay to finish instead.
+	walTargetVersion, err := db.committedVersion()
+	if err != nil {
+		return fmt.Errorf("failed to read wal version: %w", err)
+	}
+	if walTargetVersion > db.lastCommitInfo.Version {
+		return fmt.Errorf("%w (wal=%d, committed=%d)", errWALAhead, walTargetVersion, db.lastCommitInfo.Version)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	ch := make(chan snapshotResult)
@@ -902,6 +992,7 @@ func (db *DB) rewriteSnapshotBackground() error {
 
 	cloned := db.copy(0)
 	wal := db.wal
+	onCatchupMTreeLoaded := db.onCatchupMTreeLoaded
 	go func() {
 		defer close(ch)
 
@@ -916,6 +1007,9 @@ func (db *DB) rewriteSnapshotBackground() error {
 		if err != nil {
 			ch <- snapshotResult{err: err}
 			return
+		}
+		if onCatchupMTreeLoaded != nil {
+			onCatchupMTreeLoaded(mtree)
 		}
 
 		// do a best effort catch-up, will do another final catch-up in main thread.
@@ -945,16 +1039,26 @@ func (db *DB) Close() error {
 		db.snapshotRewriteCancel = nil
 	}
 
+	// The rewrite goroutine is joined above, so nothing can submit to the pool
+	// any more. Without this, pond's purger goroutine outlives every Load/Close
+	// cycle - unbounded for the read-only DBs opened per historical query.
+	if db.ownsWriterPool && db.snapshotWriterPool != nil {
+		db.snapshotWriterPool.StopAndWait()
+		db.snapshotWriterPool = nil
+	}
+
 	// wait for any in-flight prune goroutine to finish before closing the WAL.
 	db.pruneSnapshotLock.Lock()
 	defer db.pruneSnapshotLock.Unlock()
 
-	errs = append(errs,
-		db.MultiTree.Close(),
-		db.wal.Close(),
-	)
+	errs = append(errs, db.MultiTree.Close())
 
-	db.wal = nil
+	// Close must be idempotent; wal is the only field here that would panic on
+	// a second Close.
+	if db.wal != nil {
+		errs = append(errs, db.wal.Close())
+		db.wal = nil
+	}
 
 	if db.retiredMultiTree != nil {
 		errs = append(errs, db.retiredMultiTree.Close())
@@ -1369,7 +1473,8 @@ func createDBIfNotExist(dir string, initialVersion uint32, chainId string) error
 type walEntry struct {
 	index uint64
 	data  WALEntry
-	// done, if non-nil, receives this entry's write outcome (see Commit).
+	// Receives exactly one write outcome for every entry the writer accepts, so a
+	// waiter can block on it alone without also racing walQuit. Nil if unwaited.
 	done chan error
 }
 
@@ -1465,7 +1570,7 @@ func writeEntry(batch *wal.Batch, logger Logger, lastIndex uint64, entry *walEnt
 	// A version at or below lastIndex is already durable in the wal, so skipping
 	// it and reporting success is correct -- happens on replay after a restart.
 	if entry.index <= lastIndex {
-		logger.Error("commit old version idempotently", "lastIndex", lastIndex, "version", entry.index)
+		logger.Info("commit old version idempotently", "lastIndex", lastIndex, "version", entry.index)
 	} else {
 		batch.Write(entry.index, bz)
 	}

--- a/memiavl/db_bench_test.go
+++ b/memiavl/db_bench_test.go
@@ -5,6 +5,47 @@ import (
 	"testing"
 )
 
+func BenchmarkCommit(b *testing.B) {
+	for _, asyncCommit := range []bool{false, true} {
+		b.Run(fmt.Sprintf("asyncCommit=%v", asyncCommit), func(b *testing.B) {
+			benchmarkCommit(b, asyncCommit)
+		})
+	}
+}
+
+func benchmarkCommit(b *testing.B, asyncCommit bool) {
+	b.Helper()
+
+	db, err := Load(b.TempDir(), Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{"store"},
+		AsyncCommitBuffer: asyncCommitBufferFor(asyncCommit),
+	}, "bench_chain")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}()
+
+	cs := []*NamedChangeSet{{
+		Name:      "store",
+		Changeset: ChangeSet{Pairs: []*KVPair{{Key: []byte("key"), Value: []byte("value")}}},
+	}}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if err := db.ApplyChangeSets(cs); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := db.Commit(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkApplyChangeSet100(b *testing.B) {
 	benchmarkApplyChangeSet(b, 100)
 }

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -8,11 +8,13 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/wal"
 )
 
 const TestAppChainID = "test_chain"
@@ -798,6 +800,144 @@ func TestFastCommit(t *testing.T) {
 	require.NoError(t, db.Close())
 }
 
+func TestCommitFsyncsWALBeforeReturning(t *testing.T) {
+	for _, asyncCommit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("asyncCommit=%v", asyncCommit), func(t *testing.T) {
+			testCommitFsyncsWALBeforeReturning(t, asyncCommit)
+		})
+	}
+}
+
+func asyncCommitBufferFor(asyncCommit bool) int {
+	if asyncCommit {
+		return 10
+	}
+	return -1
+}
+
+func testCommitFsyncsWALBeforeReturning(t *testing.T, asyncCommit bool) {
+	t.Helper()
+
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: asyncCommitBufferFor(asyncCommit),
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	original := db.walSync
+	var syncCalls atomic.Int32
+	db.walSync = func(w *wal.Log) error {
+		syncCalls.Add(1)
+		return original(w)
+	}
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "hello", "world")))
+
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, syncCalls.Load(), "Commit must fsync the wal entry before returning")
+}
+
+func TestCommitFailsWhenWALSyncFails(t *testing.T) {
+	for _, asyncCommit := range []bool{false, true} {
+		t.Run(fmt.Sprintf("asyncCommit=%v", asyncCommit), func(t *testing.T) {
+			testCommitFailsWhenWALSyncFails(t, asyncCommit)
+		})
+	}
+}
+
+func testCommitFailsWhenWALSyncFails(t *testing.T, asyncCommit bool) {
+	t.Helper()
+
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: asyncCommitBufferFor(asyncCommit),
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	syncErr := errors.New("simulated fsync failure")
+	db.walSync = func(*wal.Log) error {
+		return syncErr
+	}
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "hello", "world")))
+
+	v, err := db.Commit()
+	require.ErrorIs(t, err, syncErr)
+	require.Zero(t, v)
+
+	// Both paths must latch the error so Close still surfaces it: the async path
+	// from the writer's terminal walQuit signal, the sync path from Commit itself.
+	require.ErrorIs(t, db.Close(), syncErr)
+}
+
+// newDBWithDeadAsyncWALWriter kills the async wal writer by closing the wal out
+// from under it and driving one Commit through the resulting error.
+func newDBWithDeadAsyncWALWriter(t *testing.T, dir string) *DB {
+	t.Helper()
+
+	db, err := Load(dir, Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: 10,
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "hello", "world")))
+
+	// close the wal out from under the writer so its next write fails.
+	require.NoError(t, db.wal.Close())
+
+	v, err := db.Commit()
+	require.ErrorIs(t, err, wal.ErrClosed)
+	require.Zero(t, v)
+
+	return db
+}
+
+func TestCommitFailsSynchronouslyOnAsyncWALWriteError(t *testing.T) {
+	dir := t.TempDir()
+	db := newDBWithDeadAsyncWALWriter(t, dir)
+
+	// release the writer (parked delivering its error on walQuit) and the file
+	// lock, without touching the now-closed wal.
+	<-db.walQuit
+	db.walChan = nil
+	db.walQuit = nil
+	db.wal = nil
+	require.NoError(t, db.fileLock.Unlock())
+	require.NoError(t, db.fileLock.Destroy())
+}
+
+func TestCommitAfterDeadAsyncWriterDoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	db := newDBWithDeadAsyncWALWriter(t, dir)
+
+	require.NoError(t, db.ApplyChangeSets([]*NamedChangeSet{
+		{Name: testStoreName, Changeset: ChangeSet{
+			Pairs: []*KVPair{{Key: []byte("hello2"), Value: []byte("world2")}},
+		}},
+	}))
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := db.Commit()
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second Commit call deadlocked waiting on a dead async wal writer")
+	}
+}
+
 func TestRepeatedApplyChangeSet(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{CreateIfMissing: true, InitialStores: []string{test1StoreName, test2StoreName}, SnapshotInterval: 3, AsyncCommitBuffer: 10}, TestAppChainID)
 	require.NoError(t, err)
@@ -900,10 +1040,7 @@ func testIdempotentWrite(t *testing.T, asyncCommit bool) {
 	t.Helper()
 	dir := t.TempDir()
 
-	asyncCommitBuffer := -1
-	if asyncCommit {
-		asyncCommitBuffer = 10
-	}
+	asyncCommitBuffer := asyncCommitBufferFor(asyncCommit)
 
 	db, err := Load(dir, Options{
 		CreateIfMissing:   true,

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -6,6 +6,7 @@ import (
 	fmt "fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"sync/atomic"
@@ -597,7 +598,8 @@ func TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure(t *testing.T)
 
 	corruptVersion := corruptTrailingWALEntry(t, db)
 	// the corrupt entry bypassed Commit, so nudge lastCommitInfo to match the wal's
-	// reported version or checkBackgroundSnapshotRewrite's wait loop spins forever.
+	// reported version or checkBackgroundSnapshotRewrite rejects the rewrite for
+	// being behind the last commit before it ever reads the corrupt entry.
 	db.lastCommitInfo.Version = corruptVersion
 
 	mtree, err := LoadMultiTree(currentPath(db.dir), db.zeroCopy, db.cacheSize, db.chainId)
@@ -612,11 +614,102 @@ func TestCheckBackgroundSnapshotRewriteClosesMTreeOnCatchupFailure(t *testing.T)
 	require.Nil(t, mtree.trees, "mtree must be closed on catchup failure, not leaked")
 }
 
-func TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure(t *testing.T) {
+func TestCheckBackgroundSnapshotRewriteDiscardsAheadResult(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Load(dir, Options{
 		CreateIfMissing: true,
 		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "hello", "world0")))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.RewriteSnapshot())
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "hello", "world1")))
+	_, err = db.Commit()
+	require.NoError(t, err)
+
+	// Simulate a rewrite result that caught up past the currently committed
+	// version, e.g. new blocks landing while the background rewrite was running.
+	// Load independently from the on-disk snapshot, the way production's
+	// rewriteSnapshotBackground goroutine hands off to the collector.
+	ahead, err := LoadMultiTree(currentPath(db.dir), db.zeroCopy, db.cacheSize, db.chainId)
+	require.NoError(t, err)
+	require.NoError(t, ahead.CatchupWAL(db.wal, 2))
+	db.lastCommitInfo.Version = ahead.Version() - 1
+	injectSnapshotRewriteResult(db, ahead)
+
+	require.NoError(t, db.checkBackgroundSnapshotRewrite(), "an ahead result must be discarded, not surfaced as a catchup error")
+	require.Nil(t, ahead.trees, "discarded mtree must be closed")
+
+	// the live db's own snapshot must be unaffected by discarding the independent one.
+	require.Equal(t, []byte("world1"), db.TreeByName(testStoreName).Get([]byte("hello")))
+}
+
+func TestCommittedVersionNilWAL(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Load(dir, Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	_, err = db.CommittedVersion()
+	require.Error(t, err)
+}
+
+func TestCommittedVersionConcurrentWithClose(t *testing.T) {
+	// CommittedVersion is exported API and must take db.mtx before reading
+	// db.wal, the same way Close takes it before nilling db.wal, or a racing
+	// caller can observe a non-nil db.wal that Close nils out from under it.
+	dir := t.TempDir()
+	db, err := Load(dir, Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "k", "v")))
+	_, err = db.Commit()
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			_, _ = db.CommittedVersion()
+		}
+	}()
+
+	require.NoError(t, db.Close())
+	<-done
+}
+
+func TestCommitAfterCloseAtSnapshotIntervalDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Load(dir, Options{
+		CreateIfMissing:  true,
+		InitialStores:    []string{testStoreName},
+		SnapshotInterval: 1,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	require.NotPanics(t, func() {
+		_, _ = db.Commit()
+	})
+}
+
+func TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Load(dir, Options{
+		CreateIfMissing:     true,
+		InitialStores:       []string{testStoreName},
+		SnapshotWriterLimit: 1,
 	}, TestAppChainID)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, db.Close()) }()
@@ -627,14 +720,33 @@ func TestRewriteSnapshotBackgroundClosesMTreeOnCatchupFailure(t *testing.T) {
 	_, err = db.Commit()
 	require.NoError(t, err)
 
-	corruptTrailingWALEntry(t, db)
+	// Occupy the sole snapshot writer so the background rewrite blocks before it
+	// writes anything. That gives us a window to append a wal entry simulating a
+	// block landing while the rewrite runs, which its post-rewrite CatchupWAL
+	// will then trip over.
+	release := make(chan struct{})
+	held := make(chan struct{})
+	db.snapshotWriterPool.Submit(func() {
+		close(held)
+		<-release
+	})
+	<-held
+
+	var loaded *MultiTree
+	db.onCatchupMTreeLoaded = func(mtree *MultiTree) { loaded = mtree }
 
 	require.NoError(t, db.RewriteSnapshotBackground())
+
+	corruptTrailingWALEntry(t, db)
+
+	close(release)
 
 	select {
 	case result := <-db.snapshotRewriteChan:
 		require.Error(t, result.err, "background catchup failure must be reported")
 		require.Nil(t, result.mtree, "no tree handed back on failure, so no way to leak it via the result")
+		require.NotNil(t, loaded, "hook must have observed the loaded mtree before catchup failed")
+		require.Nil(t, loaded.trees, "mtree must be closed on catchup failure, not leaked")
 		db.snapshotRewriteChan = nil
 		db.snapshotRewriteCancel = nil
 	case <-time.After(5 * time.Second):
@@ -1096,6 +1208,64 @@ func testIdempotentWrite(t *testing.T, asyncCommit bool) {
 	require.Equal(t, commitInfo, *db.LastCommitInfo())
 }
 
+func TestDBCloseIsIdempotent(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Close())
+	require.NoError(t, db.Close())
+}
+
+func TestSnapshotRewriteDuringWALReplay(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Load(dir, Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "hello", fmt.Sprintf("world%d", i))))
+		_, err := db.Commit()
+		require.NoError(t, err)
+	}
+	commitInfo := *db.LastCommitInfo()
+	require.NoError(t, db.Close())
+
+	// Reload below the wal's last index: the tree is at version 5 while the wal
+	// still holds entries 6..10, which the replay below writes again idempotently.
+	db, err = Load(dir, Options{TargetVersion: 5}, TestAppChainID)
+	require.NoError(t, err)
+	committedVersion, err := db.CommittedVersion()
+	require.NoError(t, err)
+	require.Equal(t, int64(10), committedVersion)
+	require.Equal(t, int64(5), db.Version())
+
+	// The per-block trigger must not start a rewrite while the wal is ahead: it
+	// would write a snapshot and replay the rest of the wal into a second tree,
+	// only to be discarded for overshooting the committed version.
+	interval := db.snapshotInterval
+	db.snapshotInterval = 1
+	db.rewriteIfApplicable(db.Version())
+	require.Nil(t, db.snapshotRewriteChan, "no rewrite may start while the wal is ahead")
+	db.snapshotInterval = interval
+
+	// An explicit rewrite must also be refused while the wal is ahead.
+	require.Error(t, db.RewriteSnapshotBackground())
+
+	for i := 5; i < 10; i++ {
+		require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "hello", fmt.Sprintf("world%d", i))))
+		_, err := db.Commit()
+		require.NoError(t, err, "commit must not fail while the wal is ahead of the tree")
+	}
+	require.Equal(t, commitInfo, *db.LastCommitInfo())
+
+	require.NoError(t, db.Close())
+}
+
 // TestEarliestVersion verifies that EarliestVersion returns the earliest
 // retained snapshot version (not the WAL FirstVersion), and that the cache
 // is refreshed by pruneSnapshots.
@@ -1320,4 +1490,30 @@ func TestSnapshotRewriteWaitAbortsOnAsyncWALError(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("snapshot rewrite catch-up spun forever after async wal writer death")
 	}
+}
+
+func TestCloseStopsSnapshotWriterPool(t *testing.T) {
+	// A DB that closes cleanly must not leave pond's purger goroutine behind:
+	// read-only DBs are opened and closed once per historical query.
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 20; i++ {
+		db, err := Load(t.TempDir(), Options{
+			CreateIfMissing: true,
+			InitialStores:   []string{testStoreName},
+		}, TestAppChainID)
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+	}
+
+	// Goroutine teardown is not instantaneous, so allow a short settle window.
+	var after int
+	for i := 0; i < 100; i++ {
+		after = runtime.NumGoroutine()
+		if after <= before+5 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("goroutines leaked across 20 Load/Close cycles: before=%d after=%d", before, after)
 }

--- a/store/memiavlstore/store.go
+++ b/store/memiavlstore/store.go
@@ -3,6 +3,7 @@ package memiavlstore
 import (
 	"fmt"
 	"io"
+	"sync/atomic"
 
 	cmtprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
 	ics23 "github.com/cosmos/ics23/go"
@@ -26,18 +27,23 @@ var (
 
 // Store Implements types.KVStore and CommitKVStore.
 type Store struct {
-	tree   *memiavl.Tree
+	// SetTree runs from rootmulti.Store.Commit while a query may run concurrently
+	// on another ABCI connection; the atomic pointer only makes the swap itself
+	// race-free, not reads racing an ApplyChangeSet on the same tree's internals.
+	tree   atomic.Pointer[memiavl.Tree]
 	logger log.Logger
 
 	changeSet memiavl.ChangeSet
 }
 
 func New(tree *memiavl.Tree, logger log.Logger) *Store {
-	return &Store{tree: tree, logger: logger}
+	st := &Store{logger: logger}
+	st.tree.Store(tree)
+	return st
 }
 
 func (st *Store) SetTree(tree *memiavl.Tree) {
-	st.tree = tree
+	st.tree.Store(tree)
 }
 
 func (st *Store) Commit() types.CommitID {
@@ -45,9 +51,10 @@ func (st *Store) Commit() types.CommitID {
 }
 
 func (st *Store) LastCommitID() types.CommitID {
-	hash := st.tree.RootHash()
+	tree := st.tree.Load()
+	hash := tree.RootHash()
 	return types.CommitID{
-		Version: st.tree.Version(),
+		Version: tree.Version(),
 		Hash:    hash,
 	}
 }
@@ -89,12 +96,12 @@ func (st *Store) Set(key, value []byte) {
 
 // Get Implements types.KVStore.
 func (st *Store) Get(key []byte) []byte {
-	return st.tree.Get(key)
+	return st.tree.Load().Get(key)
 }
 
 // Has Implements types.KVStore.
 func (st *Store) Has(key []byte) bool {
-	return st.tree.Has(key)
+	return st.tree.Load().Has(key)
 }
 
 // Delete Implements types.KVStore.
@@ -106,11 +113,11 @@ func (st *Store) Delete(key []byte) {
 }
 
 func (st *Store) Iterator(start, end []byte) types.Iterator {
-	return st.tree.Iterator(start, end, true)
+	return st.tree.Load().Iterator(start, end, true)
 }
 
 func (st *Store) ReverseIterator(start, end []byte) types.Iterator {
-	return st.tree.Iterator(start, end, false)
+	return st.tree.Load().Iterator(start, end, false)
 }
 
 // SetInitialVersion sets the initial version of the IAVL tree. It is used when
@@ -132,25 +139,26 @@ func (st *Store) Query(req *types.RequestQuery) (res *types.ResponseQuery, err e
 		return nil, errors.Wrap(types.ErrTxDecode, "query cannot be zero length")
 	}
 
-	if req.Height > 0 && req.Height != st.tree.Version() {
+	tree := st.tree.Load()
+	if req.Height > 0 && req.Height != tree.Version() {
 		return nil, errors.Wrap(sdkerrors.ErrInvalidHeight, "invalid height")
 	}
 
 	res = &types.ResponseQuery{
-		Height: st.tree.Version(),
+		Height: tree.Version(),
 	}
 
 	switch req.Path {
 	case "/key": // get by key
 		res.Key = req.Data // data holds the key bytes
-		res.Value = st.tree.Get(res.Key)
+		res.Value = tree.Get(res.Key)
 
 		if !req.Prove {
 			break
 		}
 
 		// get proof from tree and convert to merkle.Proof before adding to result
-		res.ProofOps = getProofFromTree(st.tree, req.Data, res.Value != nil)
+		res.ProofOps = getProofFromTree(tree, req.Data, res.Value != nil)
 	case "/subspace":
 		pairs := memiavl.Pairs{
 			Pairs: make([]memiavl.Pair, 0),
@@ -182,7 +190,7 @@ func (st *Store) Query(req *types.RequestQuery) (res *types.ResponseQuery, err e
 }
 
 func (st *Store) WorkingHash() []byte {
-	return st.tree.RootHash()
+	return st.tree.Load().RootHash()
 }
 
 // Takes a MutableTree, a key, and a flag for creating existence or absence proof and returns the

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -298,8 +298,6 @@ func (rs *Store) latestCommitInfo() *types.CommitInfo {
 	return rs.lastCommitInfo
 }
 
-// refreshLastCommitInfo derives commit info from db, amending it for
-// cosmos-sdk 0.46 hash-compatibility if configured.
 func (rs *Store) refreshLastCommitInfo(db *memiavl.DB) *types.CommitInfo {
 	info := convertCommitInfo(db.LastCommitInfo())
 	if rs.sdk46Compact {
@@ -308,9 +306,8 @@ func (rs *Store) refreshLastCommitInfo(db *memiavl.DB) *types.CommitInfo {
 	return info
 }
 
-// rebuildStores loads a CommitStore for every key in keys, which must be
-// pre-sorted for deterministic iteration order. Returns on the first error,
-// leaving rs.stores untouched for the caller to decide.
+// rebuildStores loads a CommitStore for every key in keys; keys must be
+// pre-sorted for deterministic iteration order.
 func (rs *Store) rebuildStores(db *memiavl.DB, keys []types.StoreKey) (map[types.StoreKey]types.CommitStore, error) {
 	newStores := make(map[types.StoreKey]types.CommitStore, len(keys))
 	for _, key := range keys {

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -216,9 +216,7 @@ func loadAtVersion(dir string, opts memiavl.Options, chainId string, version int
 type querySnapshot struct {
 	db             *memiavl.DB
 	lastCommitInfo *types.CommitInfo
-	// built once per publish, so the latest-height path doesn't rebuild a
-	// memiavlstore.Store (and rewire listeners) per query.
-	stores map[types.StoreKey]types.CacheWrapper
+	stores         map[types.StoreKey]types.CacheWrapper
 }
 
 const CommitInfoFileName = "commit_infos"
@@ -288,9 +286,6 @@ func (rs *Store) latestDB() *memiavl.DB {
 	return rs.db
 }
 
-// latestCommitInfo keeps callers that run concurrently with Commit (e.g.
-// LastCommitID, served on the ABCI Info connection) off the unsynchronized
-// rs.lastCommitInfo field.
 func (rs *Store) latestCommitInfo() *types.CommitInfo {
 	if snap := rs.querySnapshot.Load(); snap != nil {
 		return snap.lastCommitInfo
@@ -493,8 +488,7 @@ func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 }
 
 // wireListeners wraps listening-enabled stores in a listenkv.Store so listeners
-// observe writes made through the cache store; the listeners already set on the
-// underlying store would otherwise observe them twice.
+// observe writes made through the cache store.
 func (rs *Store) wireListeners(stores map[types.StoreKey]types.CacheWrapper) map[types.StoreKey]types.CacheWrapper {
 	for k, store := range stores {
 		if kv, ok := store.(types.KVStore); ok && rs.ListeningEnabled(k) {

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -210,12 +210,15 @@ func loadAtVersion(dir string, opts memiavl.Options, chainId string, version int
 	return db, nil
 }
 
-// querySnapshot is an immutable copy-on-write view of committed state, read
-// by latest-height query paths instead of the live rs.db/rs.stores to avoid
-// racing Commit's in-place mutation.
+// querySnapshot is an immutable copy-on-write view of committed state, read by
+// latest-height query paths instead of the live rs.db/rs.stores that Commit
+// mutates in place.
 type querySnapshot struct {
 	db             *memiavl.DB
 	lastCommitInfo *types.CommitInfo
+	// built once per publish, so the latest-height path doesn't rebuild a
+	// memiavlstore.Store (and rewire listeners) per query.
+	stores map[types.StoreKey]types.CacheWrapper
 }
 
 const CommitInfoFileName = "commit_infos"
@@ -270,9 +273,11 @@ func NewStore(dir string, logger log.Logger, sdk46Compact, supportExportNonSnaps
 }
 
 func (rs *Store) publishQuerySnapshot() {
+	db := rs.db.Copy()
 	rs.querySnapshot.Store(&querySnapshot{
-		db:             rs.db.Copy(),
+		db:             db,
 		lastCommitInfo: rs.lastCommitInfo,
+		stores:         rs.wireListeners(rs.storesFromDB(db)),
 	})
 }
 
@@ -281,6 +286,41 @@ func (rs *Store) latestDB() *memiavl.DB {
 		return snap.db
 	}
 	return rs.db
+}
+
+// latestCommitInfo keeps callers that run concurrently with Commit (e.g.
+// LastCommitID, served on the ABCI Info connection) off the unsynchronized
+// rs.lastCommitInfo field.
+func (rs *Store) latestCommitInfo() *types.CommitInfo {
+	if snap := rs.querySnapshot.Load(); snap != nil {
+		return snap.lastCommitInfo
+	}
+	return rs.lastCommitInfo
+}
+
+// refreshLastCommitInfo derives commit info from db, amending it for
+// cosmos-sdk 0.46 hash-compatibility if configured.
+func (rs *Store) refreshLastCommitInfo(db *memiavl.DB) *types.CommitInfo {
+	info := convertCommitInfo(db.LastCommitInfo())
+	if rs.sdk46Compact {
+		info = amendCommitInfo(info, rs.storesParams)
+	}
+	return info
+}
+
+// rebuildStores loads a CommitStore for every key in keys, which must be
+// pre-sorted for deterministic iteration order. Returns on the first error,
+// leaving rs.stores untouched for the caller to decide.
+func (rs *Store) rebuildStores(db *memiavl.DB, keys []types.StoreKey) (map[types.StoreKey]types.CommitStore, error) {
+	newStores := make(map[types.StoreKey]types.CommitStore, len(keys))
+	for _, key := range keys {
+		store, err := rs.loadCommitStoreFromParams(db, key, rs.storesParams[key])
+		if err != nil {
+			return nil, err
+		}
+		newStores[key] = store
+	}
+	return newStores, nil
 }
 
 // flush writes all the pending change sets to memiavl tree.
@@ -345,10 +385,7 @@ func (rs *Store) Commit() types.CommitID {
 		}
 	}
 
-	rs.lastCommitInfo = convertCommitInfo(rs.db.LastCommitInfo())
-	if rs.sdk46Compact {
-		rs.lastCommitInfo = amendCommitInfo(rs.lastCommitInfo, rs.storesParams)
-	}
+	rs.lastCommitInfo = rs.refreshLastCommitInfo(rs.db)
 	rs.publishQuerySnapshot()
 	return rs.lastCommitInfo.CommitID()
 }
@@ -406,7 +443,8 @@ func (rs *Store) closeDBForReload() {
 // reload - the version is read back from disk and the returned CommitID carries no
 // hash. Reporting version 0 instead would tell CometBFT to replay from genesis.
 func (rs *Store) LastCommitID() types.CommitID {
-	if rs.lastCommitInfo == nil {
+	lastCommitInfo := rs.latestCommitInfo()
+	if lastCommitInfo == nil {
 		v, err := memiavl.GetLatestVersion(rs.dir)
 		if err != nil {
 			panic(fmt.Errorf("failed to get latest version: %w", err))
@@ -414,7 +452,7 @@ func (rs *Store) LastCommitID() types.CommitID {
 		return types.CommitID{Version: v}
 	}
 
-	return rs.lastCommitInfo.CommitID()
+	return lastCommitInfo.CommitID()
 }
 
 // SetPruning Implements interface Committer
@@ -445,25 +483,31 @@ func (rs *Store) CacheWrapWithTrace(_ io.Writer, _ interface{}) types.CacheWrap 
 	return rs.CacheWrap()
 }
 
-// CacheMultiStore Implements interface MultiStore
+// CacheMultiStore Implements interface MultiStore.
+//
+// Must wrap the live rs.stores, not a querySnapshot: writes flow back through
+// cachemulti's Write(), which a snapshot-backed store would silently discard.
 func (rs *Store) CacheMultiStore() types.CacheMultiStore {
-	stores := make(map[types.StoreKey]types.CacheWrapper)
+	stores := make(map[types.StoreKey]types.CacheWrapper, len(rs.stores))
 	for k, v := range rs.stores {
-		store := types.CacheWrapper(v)
-		if kv, ok := store.(types.KVStore); ok {
-			// Wire the listenkv.Store to allow listeners to observe the writes from the cache store,
-			// set same listeners on cache store will observe duplicated writes.
-			if rs.ListeningEnabled(k) {
-				store = listenkv.NewStore(kv, k, rs.listeners[k])
-			}
-		}
-		stores[k] = store
+		stores[k] = v
 	}
-	return cachemulti.NewStore(stores, nil, nil, nil)
+	return cachemulti.NewStore(rs.wireListeners(stores), nil, nil, nil)
 }
 
-// cacheMultiStoreFromDB builds a CacheMultiStore from db's iavl trees.
-func (rs *Store) cacheMultiStoreFromDB(db *memiavl.DB, closer io.Closer) types.CacheMultiStore {
+// wireListeners wraps listening-enabled stores in a listenkv.Store so listeners
+// observe writes made through the cache store; the listeners already set on the
+// underlying store would otherwise observe them twice.
+func (rs *Store) wireListeners(stores map[types.StoreKey]types.CacheWrapper) map[types.StoreKey]types.CacheWrapper {
+	for k, store := range stores {
+		if kv, ok := store.(types.KVStore); ok && rs.ListeningEnabled(k) {
+			stores[k] = listenkv.NewStore(kv, k, rs.listeners[k])
+		}
+	}
+	return stores
+}
+
+func (rs *Store) storesFromDB(db *memiavl.DB) map[types.StoreKey]types.CacheWrapper {
 	stores := make(map[types.StoreKey]types.CacheWrapper)
 
 	// add the transient/mem stores registered in current app.
@@ -473,9 +517,8 @@ func (rs *Store) cacheMultiStoreFromDB(db *memiavl.DB, closer io.Closer) types.C
 		}
 	}
 
-	// add all the iavl stores from db. A historical snapshot may contain trees
-	// for stores later deleted/renamed by a StoreUpgrade; skip those since
-	// there's no current StoreKey to expose them under.
+	// A historical snapshot may hold trees for stores a later StoreUpgrade
+	// deleted or renamed; skip those, there's no current StoreKey for them.
 	for _, tree := range db.Trees() {
 		key, ok := rs.keysByName[tree.Name]
 		if !ok {
@@ -484,26 +527,35 @@ func (rs *Store) cacheMultiStoreFromDB(db *memiavl.DB, closer io.Closer) types.C
 		stores[key] = memiavlstore.New(tree.Tree, rs.logger)
 	}
 
-	return cachemulti.NewStore(stores, nil, nil, closer)
+	return stores
 }
 
-// CacheMultiStoreWithVersion Implements interface MultiStore
-// used to createQueryContext, abci_query or grpc query service.
+// cacheMultiStoreFromDB builds a CacheMultiStore from db's iavl trees. Pass
+// closer=db for an independently-owned db, or nil for a query snapshot, which
+// shares mmap state with rs.db and must never be closed on its own.
+func (rs *Store) cacheMultiStoreFromDB(db *memiavl.DB, closer io.Closer) types.CacheMultiStore {
+	return cachemulti.NewStore(rs.storesFromDB(db), nil, nil, closer)
+}
+
+// CacheMultiStoreWithVersion Implements interface MultiStore.
+// version == 0 means the latest committed snapshot, not the live working state.
 func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStore, error) {
 	snap := rs.querySnapshot.Load()
 	if snap == nil {
 		return nil, errors.Wrap(sdkerrors.ErrInvalidRequest, "store is not loaded")
 	}
 	if version == 0 || version == snap.lastCommitInfo.Version {
-		return rs.cacheMultiStoreFromDB(snap.db, nil), nil
+		// snap.stores is already wireListeners-wrapped from publishQuerySnapshot,
+		// so use it directly instead of rebuilding (and dropping listener wiring)
+		// via cacheMultiStoreFromDB.
+		return cachemulti.NewStore(snap.stores, nil, nil, nil), nil
 	}
 
 	if version < 0 || version > math.MaxUint32 {
 		return nil, fmt.Errorf("version out of range: %d", version)
 	}
-	// historicalDBCache isn't used here: the returned store's lifetime is owned
-	// by the caller (closed via cachemulti.NewStore's closer arg, see PR #54),
-	// not scoped to this call, so the cache's borrow/release model doesn't fit.
+	// historicalDBCache isn't used here: the caller owns the returned store's
+	// lifetime (closed via the closer arg), so the cache's borrow/release model doesn't fit.
 	db, err := loadAtVersion(rs.dir, rs.opts, rs.chainId, version)
 	if err != nil {
 		return nil, err
@@ -547,14 +599,23 @@ func (rs *Store) SetTracingContext(_ interface{}) types.MultiStore {
 
 // LatestVersion Implements interface MultiStore
 func (rs *Store) LatestVersion() int64 {
-	return rs.latestDB().Version()
+	db := rs.latestDB()
+	if db == nil {
+		// Restore closed the db and LoadLatestVersion hasn't run yet.
+		return 0
+	}
+	return db.Version()
 }
 
 // EarliestVersion Implements interface CommitMultiStore
 func (rs *Store) EarliestVersion() int64 {
+	db := rs.latestDB()
+	if db == nil {
+		return 0
+	}
 	// memiavl prunes WAL entries up to the earliest retained snapshot, so the
 	// earliest queryable version is the version of that snapshot.
-	v, err := rs.latestDB().EarliestVersion()
+	v, err := db.EarliestVersion()
 	if err != nil {
 		rs.logger.Error("failed to get earliest version", "err", err)
 		return 0
@@ -681,12 +742,9 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 		}
 	}
 
-	newStores := make(map[types.StoreKey]types.CommitStore, len(storesKeys))
-	for _, key := range storesKeys {
-		newStores[key], err = rs.loadCommitStoreFromParams(db, key, rs.storesParams[key])
-		if err != nil {
-			return err
-		}
+	newStores, err := rs.rebuildStores(db, storesKeys)
+	if err != nil {
+		return err
 	}
 
 	rs.db = db
@@ -694,10 +752,7 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 	rs.stores = newStores
 	// to keep the root hash compatible with cosmos-sdk 0.46
 	if db.Version() != 0 {
-		rs.lastCommitInfo = convertCommitInfo(db.LastCommitInfo())
-		if rs.sdk46Compact {
-			rs.lastCommitInfo = amendCommitInfo(rs.lastCommitInfo, rs.storesParams)
-		}
+		rs.lastCommitInfo = rs.refreshLastCommitInfo(db)
 	} else {
 		rs.lastCommitInfo = &types.CommitInfo{}
 	}
@@ -778,7 +833,12 @@ func (rs *Store) SetInterBlockCache(c types.MultiStorePersistentCache) {}
 // SetInitialVersion Implements interface CommitMultiStore
 // used by InitChain when the initial height is bigger than 1
 func (rs *Store) SetInitialVersion(version int64) error {
-	return rs.db.SetInitialVersion(version)
+	if err := rs.db.SetInitialVersion(version); err != nil {
+		return err
+	}
+	// keep the published snapshot from going stale against the mutated rs.db.
+	rs.publishQuerySnapshot()
+	return nil
 }
 
 // SetIAVLCacheSize Implements interface CommitMultiStore
@@ -805,8 +865,8 @@ func (rs *Store) SetMemIAVLOptions(opts memiavl.Options) {
 }
 
 // RollbackToVersion delete the versions after `target` and update the latest version.
-// it should only be called in standalone cli commands: it closes rs.db
-// outright, invalidating any querySnapshot published before this call.
+// it should only be called in standalone cli commands: it closes rs.db outright,
+// invalidating any querySnapshot published before this call.
 func (rs *Store) RollbackToVersion(target int64) error {
 	if target <= 0 {
 		return fmt.Errorf("invalid rollback height target: %d", target)
@@ -822,17 +882,31 @@ func (rs *Store) RollbackToVersion(target int64) error {
 	opts.TargetVersion = uint32(target)
 	opts.LoadForOverwriting = true
 
-	var err error
-	rs.db, err = memiavl.Load(rs.dir, opts, rs.chainId)
+	db, err := memiavl.Load(rs.dir, opts, rs.chainId)
 	if err != nil {
 		return err
 	}
-	// keep lastCommitInfo in sync with the reloaded db, so the snapshot's
-	// version checks don't compare against the pre-rollback version.
-	rs.lastCommitInfo = convertCommitInfo(rs.db.LastCommitInfo())
-	if rs.sdk46Compact {
-		rs.lastCommitInfo = amendCommitInfo(rs.lastCommitInfo, rs.storesParams)
+
+	// Rebuild rs.stores before swapping rs.db in: the old entries hold trees from
+	// the just-closed, unmapped db, and on failure rs.db must stay untouched
+	// rather than point at a db whose stores were never rebuilt.
+	keys := make([]types.StoreKey, 0, len(rs.storesParams))
+	for key := range rs.storesParams {
+		keys = append(keys, key)
 	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].Name() < keys[j].Name() })
+
+	newStores, err := rs.rebuildStores(db, keys)
+	if err != nil {
+		_ = db.Close()
+		return err
+	}
+	rs.db = db
+	rs.stores = newStores
+
+	// resync lastCommitInfo, so the snapshot's version checks don't compare
+	// against the pre-rollback version.
+	rs.lastCommitInfo = rs.refreshLastCommitInfo(rs.db)
 	rs.publishQuerySnapshot()
 
 	return nil
@@ -893,19 +967,22 @@ func (rs *Store) Query(req *types.RequestQuery) (*types.ResponseQuery, error) {
 
 	version := req.Height
 	if version == 0 {
+		db := rs.db
 		if snap != nil {
-			version = snap.lastCommitInfo.Version
-		} else {
-			version = rs.db.Version()
+			db = snap.db
 		}
+		if db == nil {
+			return nil, errors.Wrap(sdkerrors.ErrInvalidRequest, "store is not loaded")
+		}
+		version = db.Version()
 	}
 
 	if version < 0 || version > math.MaxUint32 {
 		return nil, fmt.Errorf("version out of range: %d", version)
 	}
 
-	// At the latest height, read the published snapshot instead of the live
-	// rs.db, which Commit mutates in place. Otherwise load from disk.
+	// At the latest height, read the snapshot instead of the live rs.db that
+	// Commit mutates in place. Otherwise load from disk.
 	var db *memiavl.DB
 	var borrowedEntry *historicalDBEntry
 	if snap != nil && version == snap.lastCommitInfo.Version {
@@ -956,9 +1033,13 @@ func (rs *Store) Query(req *types.RequestQuery) (*types.ResponseQuery, error) {
 		return nil, errors.Wrap(sdkerrors.ErrInvalidRequest, "proof is unexpectedly empty; ensure height has not been pruned")
 	}
 
-	commitInfo := convertCommitInfo(db.LastCommitInfo())
-	if rs.sdk46Compact {
-		commitInfo = amendCommitInfo(commitInfo, rs.storesParams)
+	// reuse the snapshot's commit info instead of paying refreshLastCommitInfo's
+	// per-store conversion on every proved query.
+	var commitInfo *types.CommitInfo
+	if snap != nil && db == snap.db {
+		commitInfo = snap.lastCommitInfo
+	} else {
+		commitInfo = rs.refreshLastCommitInfo(db)
 	}
 
 	// Restore origin path and append proof op.

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -410,6 +410,90 @@ func TestHistoricalDBCacheConcurrent(t *testing.T) {
 	require.NoError(t, cache.close())
 }
 
+func TestCacheMultiStoreWriteBack(t *testing.T) {
+	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
+
+	key := types.NewKVStoreKey("test")
+	rs.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, rs.LoadLatestVersion())
+	t.Cleanup(func() { rs.Close() })
+
+	cms := rs.CacheMultiStore()
+	cms.GetKVStore(key).Set([]byte("k"), []byte("v"))
+	cms.Write()
+
+	rs.Commit()
+
+	require.Equal(t, []byte("v"), rs.GetKVStore(key).Get([]byte("k")))
+}
+
+func TestCloseClearsQuerySnapshot(t *testing.T) {
+	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
+
+	key := types.NewKVStoreKey(testStoreName)
+	rs.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, rs.LoadLatestVersion())
+	rs.Commit() // publishes a querySnapshot backed by rs.db's mmap state.
+
+	require.NoError(t, rs.Close())
+	require.Nil(t, rs.querySnapshot.Load(), "Close must drop the querySnapshot before closing rs.db")
+}
+
+func TestRollbackToVersionRebuildsStores(t *testing.T) {
+	dir := t.TempDir()
+	rs := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+
+	key := types.NewKVStoreKey("test")
+	rs.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, rs.LoadLatestVersion())
+
+	rs.GetKVStore(key).Set([]byte("k"), []byte("v1"))
+	rs.Commit()
+	rs.GetKVStore(key).Set([]byte("k"), []byte("v2"))
+	rs.Commit()
+
+	require.NoError(t, rs.RollbackToVersion(1))
+	t.Cleanup(func() { rs.Close() })
+
+	require.Equal(t, []byte("v1"), rs.GetKVStore(key).Get([]byte("k")))
+}
+
+func TestCacheMultiStoreWithVersionZeroWiresListeners(t *testing.T) {
+	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
+
+	key := types.NewKVStoreKey(testStoreName)
+	rs.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, rs.LoadLatestVersion())
+	t.Cleanup(func() { rs.Close() })
+	rs.AddListeners([]types.StoreKey{key})
+
+	rs.Commit() // publishes the querySnapshot whose cached stores map this test targets.
+
+	cms, err := rs.CacheMultiStoreWithVersion(0)
+	require.NoError(t, err)
+	cms.GetKVStore(key).Set([]byte("k"), []byte("v"))
+	cms.Write()
+
+	require.NotEmpty(t, rs.listeners[key].PopStateCache(),
+		"CacheMultiStoreWithVersion(0) must wire listenkv for listening-enabled stores")
+}
+
+func TestSetInitialVersionRefreshesQuerySnapshot(t *testing.T) {
+	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
+
+	key := types.NewKVStoreKey("test")
+	rs.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, rs.LoadLatestVersion())
+	t.Cleanup(func() { rs.Close() })
+
+	require.NoError(t, rs.SetInitialVersion(5))
+	require.Equal(t, int64(5), rs.EarliestVersion())
+
+	commitID := rs.Commit()
+	require.Equal(t, int64(5), commitID.Version)
+	require.Equal(t, int64(5), rs.LatestVersion())
+}
+
 func TestCacheMultiStoreWithVersionCloser(t *testing.T) {
 	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
 
@@ -538,6 +622,31 @@ func TestCacheMultiStoreWithVersionHistoricalHeightSkipsDeletedStore(t *testing.
 	require.NotPanics(t, func() { cms.GetKVStore(testKey) })
 }
 
+func TestReadPathsWithClosedDB(t *testing.T) {
+	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
+
+	key := types.NewKVStoreKey(testStoreName)
+	rs.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, rs.LoadLatestVersion())
+	rs.Commit()
+
+	// mirror Restore's teardown.
+	rs.querySnapshot.Store(nil)
+	require.NoError(t, rs.db.Close())
+	rs.db = nil
+
+	require.NotPanics(t, func() {
+		require.Zero(t, rs.LatestVersion())
+		require.Zero(t, rs.EarliestVersion())
+
+		_, err := rs.Query(&types.RequestQuery{Path: "/" + testStoreName + "/key", Data: []byte("k")})
+		require.ErrorContains(t, err, "store is not loaded")
+
+		_, err = rs.CacheMultiStoreWithVersion(0)
+		require.ErrorContains(t, err, "store is not loaded")
+	})
+}
+
 func TestRestoreRejectsIAVLNodeBeforeStore(t *testing.T) {
 	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
 
@@ -607,10 +716,13 @@ func TestLatestHeightQueryRaceAgainstCommit(t *testing.T) {
 	}()
 
 	readers := []func(){
+		// wraps the live rs.stores, not the querySnapshot, so only construction is
+		// safe to exercise here -- not a read through the concurrently-mutated tree.
 		func() { store.CacheMultiStore() },
 		func() {
 			cms, err := store.CacheMultiStoreWithVersion(0)
 			if err == nil {
+				cms.GetKVStore(key).Get([]byte("k"))
 				if closer, ok := cms.(io.Closer); ok {
 					_ = closer.Close()
 				}


### PR DESCRIPTION
### What

Fixes issue #95: `memiavl.DB.Commit()` no longer returns an acknowledged app hash before its WAL entry is fsynced, on both the sync and async write paths. Also adopts the lock-free query snapshot from PR #102 in `store/rootmulti/store.go`, since it removes the need to release `db.mtx` during the new fsync wait — latest-height queries (`Query`, `CacheMultiStoreWithVersion`, `LatestVersion`, `EarliestVersion`) now read a published snapshot instead of the live db, so they never contend with an in-flight `Commit`.

####  **_Note_**
This PR should be merged as a feature branch first, after fully tested with real network, then can merge to the main branch.


### Issue

Before this fix, a crash right after `Commit()` returned but before the OS flushed the WAL entry could lose an "acknowledged" version — CometBFT and callers would believe a version was durable when it wasn't. A prior attempt (#92) fixed this by holding `db.mtx` for the whole fsync wait, but that PR was closed over throughput concerns. Adopting the query-snapshot approach first removes that concern: query paths no longer touch `rs.db`/`db.mtx` at all, so holding the mutex for the fsync wait costs nothing extra for readers.

A second, related gap: `wal.Log.Sync()` only fsyncs the *current segment file*. When a commit lands in a freshly cycled segment, that segment's directory entry isn't durable yet — a crash could still lose an acknowledged entry even with the file itself synced. Fixed by fsyncing the WAL directory alongside the segment on every commit.

### Solution

- `memiavl/db.go`: added a per-entry `done` channel and `notifyDone` helper so the async writer always reports a write outcome; `Commit()` blocks on it (async path) or calls a new `walSync` field directly (sync path) before returning. A returned `Commit()` error is now documented as fatal/non-retryable, since the in-memory tree version is advanced before the WAL write. Collapsed `checkBackgroundSnapshotRewrite`'s retry-sleep loop into a single check, since `Commit` now always waits for its own entry. Added `fsyncDir` and call it after every WAL write to close the segment-rollover gap above. `DB.copy` now carries `earliestSnapshotCache` into the clone, so a query snapshot's `EarliestVersion` doesn't rescan the snapshot dir on every call.
- `store/rootmulti/store.go`: added `querySnapshot{db, lastCommitInfo, stores}` behind an `atomic.Pointer`, published after `Commit`, `LoadVersionAndUpgrade`, `RollbackToVersion`, and `SetInitialVersion`. `Query`, `CacheMultiStoreWithVersion`, `LatestVersion`, `EarliestVersion` read the snapshot instead of live state. `Close` and `Restore` drop the snapshot before closing `rs.db`, since a stale snapshot shares `rs.db`'s mmap'd state and a concurrent reader could dereference already-unmapped memory. The closed-db case on `Query`/`LatestVersion`/`EarliestVersion`/`CacheMultiStoreWithVersion(0)` now reports "store is not loaded" instead of nil-deref panicking during the state-sync `Restore` window.

### Test

- `memiavl/db_test.go`: added `TestCommitFsyncsWALBeforeReturning`, `TestCommitFailsWhenWALSyncFails`, `TestCommitFailsSynchronouslyOnAsyncWALWriteError`, `TestCommitAfterDeadAsyncWriterDoesNotHang` (sync + async variants).
- `memiavl/db_bench_test.go`: added `BenchmarkCommit` (sync vs async, real fsync) to measure the added latency — results below.
- `store/rootmulti/store_test.go`: added `TestLatestHeightQueryRaceAgainstCommit` (run with `-race`), `TestSetInitialVersionRefreshesQuerySnapshot`, `TestRollbackToVersionRebuildsStores`, `TestCacheMultiStoreWriteBack`, `TestCacheMultiStoreWithVersionZeroWiresListeners`, `TestCloseClearsQuerySnapshot`, `TestReadPathsWithClosedDB`.

**Benchmark: cost of the fsync wait added to `Commit`**

Ran `BenchmarkCommit` (1 KV pair per commit, 300 iterations × 3) in two environments to separate the fsync cost from platform noise:

| Environment | sync `Commit` | async `Commit` | `Commit` w/ `walSync` stubbed out | `fsyncDir` alone |
|---|---|---|---|---|
| macOS, Apple M4 Max, APFS | ~4.1–4.8 ms | ~4.1–4.3 ms | ~4.0–4.1 ms | ~32–92 µs |
| Linux (arm64 container), ext4 | ~0.28–1.31 ms | ~0.28–0.40 ms | ~4.6–6.9 µs | ~2.6 µs |

Takeaways:
- On Linux, the fsync is essentially the entire cost of a commit — the non-durable path is ~5–7 µs, the fsync adds ~0.28–0.4 ms (~98% of the call). On macOS the same fsync only shows up as ~0.1–0.2 ms because APFS's `fsync` doesn't guarantee a full stable-storage barrier the way Linux's does, and the rest of `Commit` happens to be much slower there.
- In both environments the absolute added cost per commit is sub-millisecond — negligible against CometBFT's second-scale block times.
- `fsyncDir` (the directory fsync for the segment-rollover gap) is cheap on both platforms — low single-digit percent of the segment fsync it accompanies.
- Async commit no longer returns early: with the fsync wait, sync and async `Commit` latencies converge. `AsyncCommitBuffer` now buys batching across concurrent writers, not a faster acknowledgment.
- Caveat: the Linux numbers came from a Docker VM's virtual disk, which may not reach physical media on every fsync; treat them as a floor. Bare-metal NVMe is typically in the same ballpark; network-attached storage (e.g. EBS-class volumes) can be meaningfully slower.
