### PR TITLE
fix(store): publish copy-on-write trees to the mounted stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-- [#103](https://github.com/crypto-org-chain/cronos-store/pull/103) fix(memiavl,store): fix WAL durability-ack race, adopt lock-free query snapshot, publish copy-on-write trees to the mounted stores
+- [#105](https://github.com/crypto-org-chain/cronos-store/pull/105) fix(store): publish copy-on-write trees to the mounted stores
+- [#103](https://github.com/crypto-org-chain/cronos-store/pull/103) fix(memiavl,store): fix WAL durability-ack race, adopt lock-free query snapshot
 - [#86](https://github.com/crypto-org-chain/cronos-store/pull/86) fix(memiavl): close WAL after reading latest version in GetLatestVersion
 - [#82](https://github.com/crypto-org-chain/cronos-store/pull/82) fix(memiavl): close loaded MultiTree when CatchupWAL fails during snapshot rewrite
 - [#78](https://github.com/crypto-org-chain/cronos-store/pull/78) fix(store): return error for unknown store name in Query instead of panicking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- [#103](https://github.com/crypto-org-chain/cronos-store/pull/103) fix(memiavl,store): fix WAL durability-ack race, adopt lock-free query snapshot
+- [#103](https://github.com/crypto-org-chain/cronos-store/pull/103) fix(memiavl,store): fix WAL durability-ack race, adopt lock-free query snapshot, publish copy-on-write trees to the mounted stores
 - [#86](https://github.com/crypto-org-chain/cronos-store/pull/86) fix(memiavl): close WAL after reading latest version in GetLatestVersion
 - [#82](https://github.com/crypto-org-chain/cronos-store/pull/82) fix(memiavl): close loaded MultiTree when CatchupWAL fails during snapshot rewrite
 - [#78](https://github.com/crypto-org-chain/cronos-store/pull/78) fix(store): return error for unknown store name in Query instead of panicking

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -944,7 +944,7 @@ func (db *DB) rewriteIfApplicable(height int64) {
 	// would write a snapshot and replay the rest of the wal into a second tree,
 	// only to be discarded for overshooting the committed version — repeated once
 	// per interval for the whole replay. Wait for the replay to finish.
-	committedVersion, err := db.CommittedVersion()
+	committedVersion, err := db.committedVersion()
 	if err != nil {
 		db.logger.Error("failed to read wal version", "err", err)
 		return

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -1069,8 +1069,9 @@ func (db *DB) Close() error {
 
 	errs = append(errs, db.MultiTree.Close())
 
-	// Close must be idempotent; wal is the only field here that would panic on
-	// a second Close.
+	// The historical-db cache and rootmulti's cache stores all hold this db as an
+	// io.Closer, so a second Close is reachable; wal is the only field here that
+	// would panic on one.
 	if db.wal != nil {
 		errs = append(errs, db.wal.Close())
 		db.wal = nil

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -939,6 +939,22 @@ func (db *DB) rewriteIfApplicable(height int64) {
 		return
 	}
 
+	// A wal ahead of the tree means the app is still replaying versions it had
+	// committed before a restart at a lower target version. A rewrite started now
+	// would write a snapshot and replay the rest of the wal into a second tree,
+	// only to be discarded for overshooting the committed version — repeated once
+	// per interval for the whole replay. Wait for the replay to finish.
+	committedVersion, err := db.CommittedVersion()
+	if err != nil {
+		db.logger.Error("failed to read wal version", "err", err)
+		return
+	}
+	if committedVersion > height {
+		db.logger.Info("skipping snapshot rewrite while replaying the wal",
+			"wal", committedVersion, "committed", height)
+		return
+	}
+
 	if err := db.rewriteSnapshotBackground(); err != nil {
 		if errors.Is(err, errWALAhead) {
 			db.logger.Info("skipping snapshot rewrite while replaying the wal", "err", err)

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -1208,6 +1208,8 @@ func testIdempotentWrite(t *testing.T, asyncCommit bool) {
 	require.Equal(t, commitInfo, *db.LastCommitInfo())
 }
 
+// rootmulti's cache stores and the historical-db cache all hold the db as an
+// io.Closer, so a second Close must not panic on the already-closed wal.
 func TestDBCloseIsIdempotent(t *testing.T) {
 	db, err := Load(t.TempDir(), Options{
 		CreateIfMissing: true,

--- a/store/memiavlstore/store.go
+++ b/store/memiavlstore/store.go
@@ -1,7 +1,6 @@
 package memiavlstore
 
 import (
-	"fmt"
 	"io"
 	"sync/atomic"
 
@@ -159,7 +158,10 @@ func (st *Store) Query(req *types.RequestQuery) (res *types.ResponseQuery, err e
 		}
 
 		// get proof from tree and convert to merkle.Proof before adding to result
-		res.ProofOps = getProofFromTree(tree, req.Data, res.Value != nil)
+		res.ProofOps, err = getProofFromTree(tree, req.Data, res.Value != nil)
+		if err != nil {
+			return nil, err
+		}
 	case "/subspace":
 		pairs := memiavl.Pairs{
 			Pairs: make([]memiavl.Pair, 0),
@@ -168,7 +170,9 @@ func (st *Store) Query(req *types.RequestQuery) (res *types.ResponseQuery, err e
 		subspace := req.Data
 		res.Key = subspace
 
-		iterator := types.KVStorePrefixIterator(st, subspace)
+		// iterate the tree loaded above, not st: a concurrent SetTree would
+		// otherwise return pairs from a newer version than res.Height reports.
+		iterator := tree.Iterator(subspace, types.PrefixEndBytes(subspace), true)
 		for ; iterator.Valid(); iterator.Next() {
 			pairs.Pairs = append(pairs.Pairs, memiavl.Pair{Key: iterator.Key(), Value: iterator.Value()})
 		}
@@ -194,31 +198,24 @@ func (st *Store) WorkingHash() []byte {
 	return st.tree.Load().RootHash()
 }
 
-// Takes a MutableTree, a key, and a flag for creating existence or absence proof and returns the
-// appropriate merkle.Proof. Since this must be called after querying for the value, this function should never error
-// Thus, it will panic on error rather than returning it
-func getProofFromTree(tree *memiavl.Tree, key []byte, exists bool) *cmtprotocrypto.ProofOps {
+// getProofFromTree builds the merkle proof for key, either an existence or an
+// absence proof depending on `exists`. An empty tree can produce neither, so the
+// error is returned to the querier instead of taking the node down.
+func getProofFromTree(tree *memiavl.Tree, key []byte, exists bool) (*cmtprotocrypto.ProofOps, error) {
 	var (
 		commitmentProof *ics23.CommitmentProof
 		err             error
 	)
 
 	if exists {
-		// value was found
 		commitmentProof, err = tree.GetMembershipProof(key)
-		if err != nil {
-			// sanity check: If value was found, membership proof must be creatable
-			panic(fmt.Sprintf("unexpected value for empty proof: %s", err.Error()))
-		}
 	} else {
-		// value wasn't found
 		commitmentProof, err = tree.GetNonMembershipProof(key)
-		if err != nil {
-			// sanity check: If value wasn't found, nonmembership proof must be creatable
-			panic(fmt.Sprintf("unexpected error for nonexistence proof: %s", err.Error()))
-		}
+	}
+	if err != nil {
+		return nil, errors.Wrapf(sdkerrors.ErrInvalidRequest, "failed to build proof for key %X: %s", key, err)
 	}
 
 	op := types.NewIavlCommitmentOp(key, commitmentProof)
-	return &cmtprotocrypto.ProofOps{Ops: []cmtprotocrypto.ProofOp{op.ProofOp()}}
+	return &cmtprotocrypto.ProofOps{Ops: []cmtprotocrypto.ProofOp{op.ProofOp()}}, nil
 }

--- a/store/memiavlstore/store.go
+++ b/store/memiavlstore/store.go
@@ -27,9 +27,10 @@ var (
 
 // Store Implements types.KVStore and CommitKVStore.
 type Store struct {
-	// SetTree runs from rootmulti.Store.Commit while a query may run concurrently
-	// on another ABCI connection; the atomic pointer only makes the swap itself
-	// race-free, not reads racing an ApplyChangeSet on the same tree's internals.
+	// SetTree runs from rootmulti.Store.publishQuerySnapshot while queries on this
+	// Store may run on another ABCI connection, so the swap has to be atomic. The
+	// tree it publishes is a Copy(), never the live tree rootmulti's flush mutates
+	// in place, so readers holding the old pointer stay on stable nodes.
 	tree   atomic.Pointer[memiavl.Tree]
 	logger log.Logger
 

--- a/store/memiavlstore/store.go
+++ b/store/memiavlstore/store.go
@@ -199,8 +199,7 @@ func (st *Store) WorkingHash() []byte {
 }
 
 // getProofFromTree builds the merkle proof for key, either an existence or an
-// absence proof depending on `exists`. An empty tree can produce neither, so the
-// error is returned to the querier instead of taking the node down.
+// absence proof depending on `exists`.
 func getProofFromTree(tree *memiavl.Tree, key []byte, exists bool) (*cmtprotocrypto.ProofOps, error) {
 	var (
 		commitmentProof *ics23.CommitmentProof
@@ -208,12 +207,19 @@ func getProofFromTree(tree *memiavl.Tree, key []byte, exists bool) (*cmtprotocry
 	)
 
 	if exists {
+		// The value came from this same tree, so a failure here means the tree
+		// itself is inconsistent, not that the request was bad.
 		commitmentProof, err = tree.GetMembershipProof(key)
+		if err != nil {
+			return nil, errors.Wrapf(sdkerrors.ErrLogic, "failed to build membership proof for key %X: %s", key, err)
+		}
 	} else {
+		// An empty tree has no absence proof to give; report it to the querier
+		// instead of taking the node down.
 		commitmentProof, err = tree.GetNonMembershipProof(key)
-	}
-	if err != nil {
-		return nil, errors.Wrapf(sdkerrors.ErrInvalidRequest, "failed to build proof for key %X: %s", key, err)
+		if err != nil {
+			return nil, errors.Wrapf(sdkerrors.ErrInvalidRequest, "failed to build non-membership proof for key %X: %s", key, err)
+		}
 	}
 
 	op := types.NewIavlCommitmentOp(key, commitmentProof)

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -293,6 +293,7 @@ func (rs *Store) publishQuerySnapshot() {
 	for key, store := range rs.stores {
 		memiavlStore, ok := store.(*memiavlstore.Store)
 		if !ok {
+			// transient/mem stores aren't backed by a memiavl tree, nothing to republish.
 			continue
 		}
 		tree := db.TreeByName(key.Name())

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -216,7 +216,6 @@ func loadAtVersion(dir string, opts memiavl.Options, chainId string, version int
 type querySnapshot struct {
 	db             *memiavl.DB
 	lastCommitInfo *types.CommitInfo
-	stores         map[types.StoreKey]types.CacheWrapper
 }
 
 const CommitInfoFileName = "commit_infos"
@@ -283,7 +282,6 @@ func (rs *Store) publishQuerySnapshot() {
 	rs.querySnapshot.Store(&querySnapshot{
 		db:             db,
 		lastCommitInfo: rs.lastCommitInfo,
-		stores:         rs.wireListeners(rs.storesFromDB(db)),
 	})
 
 	for key, store := range rs.stores {
@@ -291,9 +289,11 @@ func (rs *Store) publishQuerySnapshot() {
 		if !ok {
 			continue
 		}
-		if tree := db.TreeByName(key.Name()); tree != nil {
-			memiavlStore.SetTree(tree)
+		tree := db.TreeByName(key.Name())
+		if tree == nil {
+			panic(fmt.Sprintf("no memiavl tree for mounted store: %s", key.Name()))
 		}
+		memiavlStore.SetTree(tree)
 	}
 }
 
@@ -539,18 +539,19 @@ func (rs *Store) cacheMultiStoreFromDB(db *memiavl.DB, closer io.Closer) types.C
 	return cachemulti.NewStore(rs.storesFromDB(db), nil, nil, closer)
 }
 
-// CacheMultiStoreWithVersion Implements interface MultiStore.
+// CacheMultiStoreWithVersion Implements interface MultiStore
+// used to createQueryContext, abci_query or grpc query service.
+//
 // version == 0 means the latest committed snapshot, not the live working state.
+// The snapshot-backed stores are read-only: nothing flushes their change sets,
+// so a caller's Write() is discarded rather than committed.
 func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStore, error) {
 	snap := rs.querySnapshot.Load()
 	if snap == nil {
 		return nil, errors.Wrap(sdkerrors.ErrInvalidRequest, "store is not loaded")
 	}
 	if version == 0 || version == snap.lastCommitInfo.Version {
-		// snap.stores is already wireListeners-wrapped from publishQuerySnapshot,
-		// so use it directly instead of rebuilding (and dropping listener wiring)
-		// via cacheMultiStoreFromDB.
-		return cachemulti.NewStore(snap.stores, nil, nil, nil), nil
+		return rs.cacheMultiStoreFromDB(snap.db, nil), nil
 	}
 
 	if version < 0 || version > math.MaxUint32 {

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -270,6 +270,14 @@ func NewStore(dir string, logger log.Logger, sdk46Compact, supportExportNonSnaps
 	}
 }
 
+// publishQuerySnapshot publishes an immutable view of the committed state and
+// repoints the mounted iavl stores at it.
+//
+// The mounted stores must read the snapshot's trees, not rs.db's: rs.flush()
+// applies change sets to the live trees in place, while readers branched off
+// rs.stores (baseapp's CheckTx state, for one) can still be calling Get on them
+// from another ABCI connection. Copy() bumps the source's copy-on-write version,
+// so the snapshot's trees are never mutated underneath those readers.
 func (rs *Store) publishQuerySnapshot() {
 	db := rs.db.Copy()
 	rs.querySnapshot.Store(&querySnapshot{
@@ -277,6 +285,16 @@ func (rs *Store) publishQuerySnapshot() {
 		lastCommitInfo: rs.lastCommitInfo,
 		stores:         rs.wireListeners(rs.storesFromDB(db)),
 	})
+
+	for key, store := range rs.stores {
+		memiavlStore, ok := store.(*memiavlstore.Store)
+		if !ok {
+			continue
+		}
+		if tree := db.TreeByName(key.Name()); tree != nil {
+			memiavlStore.SetTree(tree)
+		}
+	}
 }
 
 func (rs *Store) latestDB() *memiavl.DB {
@@ -369,15 +387,8 @@ func (rs *Store) Commit() types.CommitID {
 		panic(err)
 	}
 
-	// the underlying memiavl tree might be reloaded, update the tree.
-	for key := range rs.stores {
-		store := rs.stores[key]
-		if store.GetStoreType() == types.StoreTypeIAVL {
-			store.(*memiavlstore.Store).SetTree(rs.db.TreeByName(key.Name()))
-		}
-	}
-
 	rs.lastCommitInfo = rs.refreshLastCommitInfo(rs.db)
+	// also repoints the mounted stores' trees, which db.Commit may have reloaded.
 	rs.publishQuerySnapshot()
 	return rs.lastCommitInfo.CommitID()
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -549,8 +549,10 @@ func (rs *Store) cacheMultiStoreFromDB(db *memiavl.DB, closer io.Closer) types.C
 // used to createQueryContext, abci_query or grpc query service.
 //
 // version == 0 means the latest committed snapshot, not the live working state.
-// The snapshot-backed stores are read-only: nothing flushes their change sets,
-// so a caller's Write() is discarded rather than committed.
+// The snapshot-backed iavl stores are read-only: nothing flushes their change
+// sets, so a caller's Write() is discarded rather than committed. The transient
+// and mem stores come from rs.stores, though, so a Write() does reach those —
+// same as before this snapshot path existed.
 func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStore, error) {
 	snap := rs.querySnapshot.Load()
 	if snap == nil {

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -277,6 +277,12 @@ func NewStore(dir string, logger log.Logger, sdk46Compact, supportExportNonSnaps
 // rs.stores (baseapp's CheckTx state, for one) can still be calling Get on them
 // from another ABCI connection. Copy() bumps the source's copy-on-write version,
 // so the snapshot's trees are never mutated underneath those readers.
+//
+// The publish is not atomic across stores: a concurrent CheckTx reader can see
+// one mounted store already on the new version while another is still on the
+// old one. Consensus state is unaffected — block execution runs on this
+// goroutine, after the publish — and a torn view only costs CheckTx an
+// occasional stale read.
 func (rs *Store) publishQuerySnapshot() {
 	db := rs.db.Copy()
 	rs.querySnapshot.Store(&querySnapshot{

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -891,8 +891,7 @@ func (rs *Store) RollbackToVersion(target int64) error {
 	}
 
 	// Rebuild rs.stores before swapping rs.db in: the old entries hold trees from
-	// the just-closed, unmapped db, and on failure rs.db must stay untouched
-	// rather than point at a db whose stores were never rebuilt.
+	// the just-closed, unmapped db.
 	keys := make([]types.StoreKey, 0, len(rs.storesParams))
 	for key := range rs.storesParams {
 		keys = append(keys, key)

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -582,6 +582,17 @@ func TestQueryEmptyStoreName(t *testing.T) {
 	}
 }
 
+// A deferred Close alongside an explicit one must not double-close the memiavl
+// db, whose wal is already nil after the first call.
+func TestCloseIsIdempotent(t *testing.T) {
+	store := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
+	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
+	require.NoError(t, store.LoadLatestVersion())
+
+	require.NoError(t, store.Close())
+	require.NoError(t, store.Close())
+}
+
 // An empty tree can't produce a non-existence proof, so the query must fail
 // with an error rather than panic the node.
 func TestQueryProveAgainstEmptyStore(t *testing.T) {
@@ -595,7 +606,7 @@ func TestQueryProveAgainstEmptyStore(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, res)
 	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
-	require.Contains(t, err.Error(), "failed to build proof")
+	require.Contains(t, err.Error(), "failed to build non-membership proof")
 }
 
 func TestQueryHistoricalHeightAllowsDeletedStore(t *testing.T) {

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -715,10 +715,14 @@ func TestLatestHeightQueryRaceAgainstCommit(t *testing.T) {
 		}
 	}()
 
+	// mimics baseapp's CheckTx state: branched off the live rs.stores once, then
+	// read from another connection while commits flush change sets into the trees.
+	checkState := store.CacheMultiStore()
+
 	readers := []func(){
-		// wraps the live rs.stores, not the querySnapshot, so only construction is
-		// safe to exercise here -- not a read through the concurrently-mutated tree.
-		func() { store.CacheMultiStore() },
+		func() { store.CacheMultiStore().GetKVStore(key).Get([]byte("k")) },
+		func() { checkState.GetKVStore(key).Get([]byte("k")) },
+		func() { store.GetKVStore(key).Get([]byte("k")) },
 		func() {
 			cms, err := store.CacheMultiStoreWithVersion(0)
 			if err == nil {

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -764,10 +764,13 @@ func TestLatestHeightQueryRaceAgainstCommit(t *testing.T) {
 			}
 		},
 		func() {
-			_, _ = store.Query(&types.RequestQuery{Path: "/" + testStoreName, Data: []byte("k")})
+			_, _ = store.Query(&types.RequestQuery{Path: "/" + testStoreName + "/key", Data: []byte("k")})
 		},
 		func() {
-			_, _ = store.Query(&types.RequestQuery{Path: "/" + testStoreName, Data: []byte("k"), Prove: true})
+			_, _ = store.Query(&types.RequestQuery{Path: "/" + testStoreName + "/key", Data: []byte("k"), Prove: true})
+		},
+		func() {
+			_, _ = store.Query(&types.RequestQuery{Path: "/" + testStoreName + "/subspace", Data: []byte("k")})
 		},
 		func() { store.LatestVersion() },
 		func() { store.EarliestVersion() },

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -582,6 +582,22 @@ func TestQueryEmptyStoreName(t *testing.T) {
 	}
 }
 
+// An empty tree can't produce a non-existence proof, so the query must fail
+// with an error rather than panic the node.
+func TestQueryProveAgainstEmptyStore(t *testing.T) {
+	store := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
+	store.MountStoreWithDB(types.NewKVStoreKey(testStoreName), types.StoreTypeIAVL, nil)
+	require.NoError(t, store.LoadLatestVersion())
+	t.Cleanup(func() { store.Close() })
+	store.Commit()
+
+	res, err := store.Query(&types.RequestQuery{Path: "/" + testStoreName + "/key", Data: []byte("k"), Prove: true})
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.ErrorIs(t, err, sdkerrors.ErrInvalidRequest)
+	require.Contains(t, err.Error(), "failed to build proof")
+}
+
 func TestQueryHistoricalHeightAllowsDeletedStore(t *testing.T) {
 	dir := t.TempDir()
 	setupOldStoreAtVersion2(t, dir, []*memiavl.TreeNameUpgrade{{Name: oldStoreName, Delete: true}})

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -458,7 +458,7 @@ func TestRollbackToVersionRebuildsStores(t *testing.T) {
 	require.Equal(t, []byte("v1"), rs.GetKVStore(key).Get([]byte("k")))
 }
 
-func TestCacheMultiStoreWithVersionZeroWiresListeners(t *testing.T) {
+func TestCacheMultiStoreWithVersionZeroIsReadOnly(t *testing.T) {
 	rs := NewStore(t.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
 
 	key := types.NewKVStoreKey(testStoreName)
@@ -467,15 +467,19 @@ func TestCacheMultiStoreWithVersionZeroWiresListeners(t *testing.T) {
 	t.Cleanup(func() { rs.Close() })
 	rs.AddListeners([]types.StoreKey{key})
 
-	rs.Commit() // publishes the querySnapshot whose cached stores map this test targets.
+	rs.Commit() // publishes the querySnapshot this test queries against.
 
 	cms, err := rs.CacheMultiStoreWithVersion(0)
 	require.NoError(t, err)
 	cms.GetKVStore(key).Set([]byte("k"), []byte("v"))
 	cms.Write()
 
-	require.NotEmpty(t, rs.listeners[key].PopStateCache(),
-		"CacheMultiStoreWithVersion(0) must wire listenkv for listening-enabled stores")
+	// Nothing flushes a snapshot-backed store's change set, so the write is
+	// dropped; it must not reach the listener stream either, or the next block
+	// would emit a state change that was never committed.
+	require.Empty(t, rs.listeners[key].PopStateCache())
+	rs.Commit()
+	require.Nil(t, rs.GetKVStore(key).Get([]byte("k")))
 }
 
 func TestSetInitialVersionRefreshesQuerySnapshot(t *testing.T) {


### PR DESCRIPTION
### What

Makes `rootmulti.Store.publishQuerySnapshot` repoint the mounted memiavl stores at the query snapshot's trees instead of the live ones, so a reader branched off `rs.stores` never sees a tree that `flush()` is mutating. Also two fixes from the review of that change: the background snapshot rewrite in `memiavl.DB` no longer fails `Commit` when the WAL is ahead of the tree, and `CacheMultiStoreWithVersion` stops sharing one store set across concurrent callers.

Stacked on #103 — review that one first.

### Issue

**#104 — reads race an in-place `ApplyChangeSet`.** #103 gave latest-height queries a lock-free `querySnapshot`, but the *mounted* stores (`rs.stores`) still pointed at the live trees. `rs.flush()` calls `db.ApplyChangeSets`, which mutates those trees in place, while a reader branched off `rs.stores` earlier — baseapp's CheckTx state, on the mempool ABCI connection — is calling `Get` on the same `*memiavl.Tree`. `-race` reports it, and a real read can land on a half-updated node.

**WAL ahead of the tree.** After a `TargetVersion` load or a rollback, the tree sits below the WAL's last index while the app re-commits the missing versions. `checkBackgroundSnapshotRewrite` treated that as an error, and `rootmulti.Commit` turns a commit error into a panic — so a node that loaded at a lower version with a background rewrite in flight crash-loops on restart.

**Shared read-only stores.** `querySnapshot` cached one `listenkv`-wrapped store set for every `CacheMultiStoreWithVersion(0)` caller. Those stores are read-only (nothing flushes their change sets), so a query's write is dropped — but it still reached the listener stream, meaning the next block would emit a state change that was never committed.

### Solution

- `publishQuerySnapshot` already makes a `db.Copy()` for the snapshot. `Copy()` bumps the source's copy-on-write version, so the copy's trees are never mutated in place. Handing those trees to the mounted stores via the existing atomic `SetTree` costs nothing extra and gets the protection for free. The old post-`db.Commit()` `SetTree` loop in `Commit` is gone — `publishQuerySnapshot` covers it.
  - Tradeoff: each block the mounted stores get a tree with a cold value cache, since `Copy()` allocates a fresh one. That is inherent to the copy-on-write approach.
- `checkBackgroundSnapshotRewrite` now errors only when the WAL is *behind* the last commit, caps its final `CatchupWAL` at `lastCommitInfo.Version`, and **discards** a result that overshot — the background goroutine's own catch-up replays to the end of the WAL and can't be rolled back, so the result is closed and a later rewrite runs once the replay finishes.
- Dropped `querySnapshot.stores`; the snapshot branch of `CacheMultiStoreWithVersion` builds fresh stores per caller with no listeners attached.
- `publishQuerySnapshot` panics on a mounted store with no memiavl tree instead of silently skipping the swap and leaving it on a stale tree.

### Test

- `TestLatestHeightQueryRaceAgainstCommit` (`store/rootmulti`) gained a reader that branches off `rs.stores` once and then reads while commits flush — the CheckTx pattern. Verified it catches the bug: with the fix stashed, `-race` reports 5 data races; with it applied, clean.
- `TestSnapshotRewriteDuringWALReplay` (`memiavl`) loads at `TargetVersion: 5` with the WAL at 10, starts a background rewrite, and collects the result mid-replay at version 6. Without the fix it fails with `wal version 10 does not match last commit version 6`.
- `TestCacheMultiStoreWithVersionZeroIsReadOnly` replaces `TestCacheMultiStoreWithVersionZeroWiresListeners`, which asserted the old behavior (a discarded write reaching the listener stream).
- Full `go test -race ./...` passes in both `memiavl/` and `store/` on macOS 15.5 / arm64.