### PR TITLE
fix(memiavl): reject metadata with no commit info and stop caching the earliest-version fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#TBD](https://github.com/crypto-org-chain/cronos-store/pull/TBD) fix(memiavl): reject metadata with no commit info and stop caching the earliest-version fallback
 - [#86](https://github.com/crypto-org-chain/cronos-store/pull/86) fix(memiavl): close WAL after reading latest version in GetLatestVersion
 - [#82](https://github.com/crypto-org-chain/cronos-store/pull/82) fix(memiavl): close loaded MultiTree when CatchupWAL fails during snapshot rewrite
 - [#78](https://github.com/crypto-org-chain/cronos-store/pull/78) fix(store): return error for unknown store name in Query instead of panicking

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ build-versiondb:
 test: test-memiavl test-store test-versiondb
 
 test-memiavl:
-	@cd memiavl && go test -tags=objstore -v -mod=readonly ./... -coverprofile=$(COVERAGE) -covermode=atomic;
+	@cd memiavl && go test -tags=objstore -v -race -mod=readonly ./... -coverprofile=$(COVERAGE) -covermode=atomic;
 
 test-store:
-	@cd store && go test -tags=objstore -v -mod=readonly ./... -coverprofile=$(COVERAGE) -covermode=atomic;
+	@cd store && go test -tags=objstore -v -race -mod=readonly ./... -coverprofile=$(COVERAGE) -covermode=atomic;
 
 test-versiondb:
 	@cd versiondb && go test -tags=objstore -v -mod=readonly ./... -coverprofile=$(COVERAGE) -covermode=atomic;

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -620,10 +620,13 @@ func (db *DB) pruneSnapshots() {
 		// truncate WAL until the earliest remaining snapshot
 		earliestVersion, err := firstSnapshotVersion(db.dir)
 		if err != nil {
+			// The snapshots are already deleted, so a cached version may name one of
+			// them. Invalidate to force readers back to a directory scan.
+			db.earliestSnapshotCache.Store(0)
 			db.logger.Error("failed to find first snapshot", "err", err)
-		} else {
-			db.earliestSnapshotCache.Store(earliestVersion)
+			return
 		}
+		db.earliestSnapshotCache.Store(earliestVersion)
 
 		if err := wal.TruncateFront(walIndex(earliestVersion+1, initialVersion)); err != nil {
 			db.logger.Error("failed to truncate wal", "err", err, "version", earliestVersion+1)
@@ -1031,11 +1034,13 @@ func (db *DB) EarliestVersion() (int64, error) {
 	}
 	if v == 0 {
 		// snapshot-0 is the genesis placeholder; the first queryable height is
-		// initialVersion (defaults to 1 for standard chains).
-		v = int64(db.initialVersion)
-		if v == 0 {
+		// initialVersion (defaults to 1 for standard chains). Don't cache this
+		// fallback: it isn't a real snapshot version, and caching it would keep
+		// EarliestVersion reporting a stale value once a snapshot actually appears.
+		if v = int64(db.initialVersion); v == 0 {
 			v = 1
 		}
+		return v, nil
 	}
 	db.earliestSnapshotCache.Store(v)
 	return v, nil

--- a/memiavl/db_test.go
+++ b/memiavl/db_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -1012,6 +1013,61 @@ func TestEarliestVersion(t *testing.T) {
 	earliest2, err := db.EarliestVersion()
 	require.NoError(t, err)
 	require.Equal(t, earliest, earliest2)
+}
+
+func TestEarliestVersionFallbackNotCached(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	// Only the genesis placeholder snapshot-0 exists, so EarliestVersion
+	// falls back to initialVersion.
+	fallback, err := db.EarliestVersion()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fallback)
+
+	// The fallback isn't a real snapshot version. Caching it would make
+	// EarliestVersion keep reporting it forever, since the cache short-circuits
+	// before a directory scan could ever discover a real snapshot later.
+	require.Zero(t, db.earliestSnapshotCache.Load(), "fallback value must not be cached")
+}
+
+func TestPruneSnapshotsInvalidatesCacheOnFirstSnapshotError(t *testing.T) {
+	db, err := Load(t.TempDir(), Options{
+		CreateIfMissing: true,
+		InitialStores:   []string{testStoreName},
+		InitialVersion:  100,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	require.NoError(t, db.ApplyChangeSets(mockNameChangeSet(testStoreName, "k", "v")))
+	_, err = db.Commit()
+	require.NoError(t, err)
+
+	// Poison the cache, as if pruning had previously found a real snapshot.
+	db.earliestSnapshotCache.Store(100)
+
+	// Remove every snapshot directory so firstSnapshotVersion fails; the
+	// "current" symlink still resolves by name, so pruneSnapshots gets past
+	// the currentVersion() read before hitting the failure.
+	entries, err := os.ReadDir(db.dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), SnapshotPrefix) {
+			require.NoError(t, os.RemoveAll(filepath.Join(db.dir, e.Name())))
+		}
+	}
+
+	db.pruneSnapshots()
+	db.pruneSnapshotLock.Lock()
+	db.pruneSnapshotLock.Unlock() //nolint:staticcheck // empty section intentional: Lock blocks until prune goroutine finishes
+
+	require.EqualValues(t, 0, db.earliestSnapshotCache.Load(),
+		"cache must be invalidated rather than left pointing at an already-deleted snapshot")
 }
 
 // TestEarliestVersionUnpruned verifies that EarliestVersion does not report

--- a/memiavl/multitree.go
+++ b/memiavl/multitree.go
@@ -502,6 +502,12 @@ func readMetadata(dir string) (*MultiTreeMetadata, error) {
 	if err := metadata.Unmarshal(bz); err != nil {
 		return nil, err
 	}
+	// WriteMetadata truncates in place, so a crash between truncate and write
+	// leaves a zero-length file that unmarshals into a metadata with no commit
+	// info. Reject it here rather than nil-deref below.
+	if metadata.CommitInfo == nil {
+		return nil, fmt.Errorf("metadata file %s is missing commit info", filepath.Join(dir, MetadataFileName))
+	}
 	if metadata.CommitInfo.Version > math.MaxUint32 {
 		return nil, fmt.Errorf("commit info version overflows uint32: %d", metadata.CommitInfo.Version)
 	}

--- a/memiavl/multitree_test.go
+++ b/memiavl/multitree_test.go
@@ -474,3 +474,14 @@ func TestLoadMultiTreeRejectsStaleMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestReadMetadataRejectsMissingCommitInfo(t *testing.T) {
+	// WriteMetadata truncates in place, so a crash mid-write leaves a zero-length
+	// file that unmarshals cleanly into a metadata with no commit info.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, MetadataFileName), nil, 0o600))
+
+	_, err := readMetadata(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing commit info")
+}


### PR DESCRIPTION
### What

Fixes two related bugs in `memiavl`'s metadata and earliest-version handling: `readMetadata` no longer nil-derefs on a metadata file with no commit info, and `EarliestVersion`/`pruneSnapshots` stop caching a stale earliest-version fallback. Also turns on `-race` for the `test-memiavl` and `test-store` Makefile targets.

### Issue

`WriteMetadata` truncates the metadata file in place before writing. A crash between the truncate and the write leaves a zero-length file that unmarshals into a `MultiTreeMetadata` with a nil `CommitInfo`. `readMetadata` then dereferenced `metadata.CommitInfo.Version` directly, panicking on load.

Separately, `EarliestVersion` cached `initialVersion` as a fallback when no snapshot existed yet (version 0). That's not a real snapshot version — once a real snapshot appears, the cached fallback kept being returned, permanently reporting a stale earliest version. `pruneSnapshots` had the same class of bug: on a failed snapshot scan, it kept the old cached earliest-snapshot value, which could name an already-deleted snapshot.

### Solution

- `readMetadata` (`memiavl/multitree.go`) rejects a metadata file with `CommitInfo == nil` with a clear error instead of dereferencing it.
- `EarliestVersion` (`memiavl/db.go`) returns the `initialVersion` fallback directly without caching it, so the cache stays empty until a real snapshot exists.
- `pruneSnapshots` invalidates the earliest-snapshot cache (stores 0) and skips the WAL truncate when the first-snapshot scan fails, instead of trusting a value that may point at a snapshot that no longer exists.
- Adds `-race` to `test-memiavl`/`test-store` Makefile targets so these classes of bug are caught by CI.

### Test

- Added unit tests in `memiavl/db_test.go` and `memiavl/multitree_test.go` covering: `readMetadata` on a zero-length/no-commit-info metadata file, `EarliestVersion` not caching the `initialVersion` fallback, and `pruneSnapshots` invalidating the cache on a failed scan.
- Ran `go test -race -count=1 ./...` for the `memiavl` module — all passing.