### PR TITLE
fix(store): disable zero-copy for historical queries so results outlive the DB cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [#110](https://github.com/crypto-org-chain/cronos-store/pull/110) fix(store): disable zero-copy for historical queries so results outlive the DB cache
 - [#85](https://github.com/crypto-org-chain/cronos-store/pull/85) fix(memiavl): preserve configured CacheSize across background snapshot rewrite
 - [#86](https://github.com/crypto-org-chain/cronos-store/pull/86) fix(memiavl): close WAL after reading latest version in GetLatestVersion
 - [#82](https://github.com/crypto-org-chain/cronos-store/pull/82) fix(memiavl): close loaded MultiTree when CatchupWAL fails during snapshot rewrite

--- a/memiavl/iterator.go
+++ b/memiavl/iterator.go
@@ -12,8 +12,6 @@ type Iterator struct {
 	key, value []byte
 
 	// clones of key/value handed out when zeroCopy is off, reset on every Next.
-	// Callers treat them as read-only (dbm.Iterator contract), so one clone per
-	// position is enough — merge iterators call Key() several times per element.
 	keyCopy, valueCopy []byte
 
 	valid bool

--- a/memiavl/iterator.go
+++ b/memiavl/iterator.go
@@ -11,6 +11,11 @@ type Iterator struct {
 	// cache the next key-value pair
 	key, value []byte
 
+	// clones of key/value handed out when zeroCopy is off, reset on every Next.
+	// Callers treat them as read-only (dbm.Iterator contract), so one clone per
+	// position is enough — merge iterators call Key() several times per element.
+	keyCopy, valueCopy []byte
+
 	valid bool
 
 	stack []Node
@@ -51,7 +56,10 @@ func (iter *Iterator) Error() error {
 // Key implements dbm.Iterator
 func (iter *Iterator) Key() []byte {
 	if !iter.zeroCopy {
-		return bytes.Clone(iter.key)
+		if iter.keyCopy == nil {
+			iter.keyCopy = bytes.Clone(iter.key)
+		}
+		return iter.keyCopy
 	}
 	return iter.key
 }
@@ -59,13 +67,18 @@ func (iter *Iterator) Key() []byte {
 // Value implements dbm.Iterator
 func (iter *Iterator) Value() []byte {
 	if !iter.zeroCopy {
-		return bytes.Clone(iter.value)
+		if iter.valueCopy == nil {
+			iter.valueCopy = bytes.Clone(iter.value)
+		}
+		return iter.valueCopy
 	}
 	return iter.value
 }
 
 // Next implements dbm.Iterator
 func (iter *Iterator) Next() {
+	iter.keyCopy, iter.valueCopy = nil, nil
+
 	for len(iter.stack) > 0 {
 		// pop node
 		node := iter.stack[len(iter.stack)-1]

--- a/memiavl/iterator_bench_test.go
+++ b/memiavl/iterator_bench_test.go
@@ -1,0 +1,40 @@
+package memiavl
+
+import "testing"
+
+// mirrors the cachekv merge iterator, which calls Key() several times per
+// position (compare in Next/Valid, then again in Key/Value)
+func BenchmarkIteratorRepeatedKeyAccess(b *testing.B) {
+	tmpDir := b.TempDir()
+	tree := New(0)
+	for _, changes := range ChangeSets[:6] {
+		tree.ApplyChangeSet(changes)
+		if _, _, err := tree.SaveVersion(true); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if err := tree.WriteSnapshot(tmpDir); err != nil {
+		b.Fatal(err)
+	}
+
+	snapshot, err := OpenSnapshot(tmpDir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	ptree := NewFromSnapshot(snapshot, false, 0)
+	b.Cleanup(func() { ptree.Close() })
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	var sink int
+	for i := 0; i < b.N; i++ {
+		iter := ptree.Iterator(nil, nil, true)
+		for ; iter.Valid(); iter.Next() {
+			sink += len(iter.Key()) + len(iter.Key()) + len(iter.Key()) + len(iter.Value())
+		}
+		if err := iter.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	_ = sink
+}

--- a/memiavl/iterator_bench_test.go
+++ b/memiavl/iterator_bench_test.go
@@ -2,8 +2,6 @@ package memiavl
 
 import "testing"
 
-// mirrors the cachekv merge iterator, which calls Key() several times per
-// position (compare in Next/Valid, then again in Key/Value)
 func BenchmarkIteratorRepeatedKeyAccess(b *testing.B) {
 	tmpDir := b.TempDir()
 	tree := New(0)

--- a/memiavl/iterator_test.go
+++ b/memiavl/iterator_test.go
@@ -1,7 +1,10 @@
 package memiavl
 
 import (
+	"bytes"
+	"runtime/debug"
 	"testing"
+	"unsafe"
 
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/stretchr/testify/require"
@@ -37,6 +40,46 @@ func TestIteratorRange(t *testing.T) {
 	}
 	require.Equal(t, expItems, collectIter(tree.Iterator([]byte("aello05"), []byte("aello10"), true)))
 	require.Equal(t, reverse(expItems), collectIter(tree.Iterator([]byte("aello05"), []byte("aello10"), false)))
+}
+
+func TestIteratorZeroCopyDisabledClonesPerPosition(t *testing.T) {
+	tmpDir := t.TempDir()
+	tree := New(0)
+	for _, changes := range ChangeSets[:6] {
+		tree.ApplyChangeSet(changes)
+		_, _, err := tree.SaveVersion(true)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tree.WriteSnapshot(tmpDir))
+
+	snapshot, err := OpenSnapshot(tmpDir)
+	require.NoError(t, err)
+	ptree := NewFromSnapshot(snapshot, false, 0)
+
+	iter := ptree.Iterator(nil, nil, true)
+	require.True(t, iter.Valid())
+
+	// repeated calls at one position reuse the same clone rather than allocating again
+	require.Same(t, unsafe.SliceData(iter.Key()), unsafe.SliceData(iter.Key()))
+	require.Same(t, unsafe.SliceData(iter.Value()), unsafe.SliceData(iter.Value()))
+
+	retained := pair{key: iter.Key(), value: iter.Value()}
+	want := pair{key: bytes.Clone(retained.key), value: bytes.Clone(retained.value)}
+
+	iter.Next()
+	require.True(t, iter.Valid())
+	// advancing must hand out a fresh clone, not overwrite what the caller already holds
+	require.NotSame(t, unsafe.SliceData(retained.key), unsafe.SliceData(iter.Key()))
+	require.NotSame(t, unsafe.SliceData(retained.value), unsafe.SliceData(iter.Value()))
+
+	collected := collectIter(iter)
+	require.NoError(t, iter.Close())
+	require.NoError(t, ptree.Close())
+
+	// a clone still aliasing the unmapped snapshot faults; make that a failing panic
+	defer debug.SetPanicOnFault(debug.SetPanicOnFault(true))
+	require.Equal(t, want, retained)
+	require.Equal(t, ExpectItems[6][1:], collected)
 }
 
 type pair struct {

--- a/memiavl/proof.go
+++ b/memiavl/proof.go
@@ -93,6 +93,9 @@ func (t *Tree) createExistenceProof(key []byte) (*ics23.ExistenceProof, error) {
 	}
 
 	path, node, err := pathToLeaf(t.root, key)
+	if err != nil {
+		return nil, err
+	}
 	// PersistedNode.Key()/Value() alias the mmap unconditionally, unlike Tree.Get, so clone under zeroCopy.
 	nodeKey, nodeValue := node.Key(), node.Value()
 	if !t.zeroCopy {
@@ -104,7 +107,7 @@ func (t *Tree) createExistenceProof(key []byte) (*ics23.ExistenceProof, error) {
 		Value: nodeValue,
 		Leaf:  convertLeafOp(int64(node.Version())),
 		Path:  convertInnerOps(path),
-	}, err
+	}, nil
 }
 
 func convertLeafOp(version int64) *ics23.LeafOp {

--- a/memiavl/proof.go
+++ b/memiavl/proof.go
@@ -93,9 +93,17 @@ func (t *Tree) createExistenceProof(key []byte) (*ics23.ExistenceProof, error) {
 	}
 
 	path, node, err := pathToLeaf(t.root, key)
+	// node.Key()/Value() on a PersistedNode alias the snapshot's mmap
+	// unconditionally (unlike Tree.Get, they have no zero-copy gate of their
+	// own), so clone them here under the same zeroCopy flag.
+	nodeKey, nodeValue := node.Key(), node.Value()
+	if !t.zeroCopy {
+		nodeKey = bytes.Clone(nodeKey)
+		nodeValue = bytes.Clone(nodeValue)
+	}
 	return &ics23.ExistenceProof{
-		Key:   node.Key(),
-		Value: node.Value(),
+		Key:   nodeKey,
+		Value: nodeValue,
 		Leaf:  convertLeafOp(int64(node.Version())),
 		Path:  convertInnerOps(path),
 	}, err

--- a/memiavl/proof.go
+++ b/memiavl/proof.go
@@ -93,9 +93,7 @@ func (t *Tree) createExistenceProof(key []byte) (*ics23.ExistenceProof, error) {
 	}
 
 	path, node, err := pathToLeaf(t.root, key)
-	// node.Key()/Value() on a PersistedNode alias the snapshot's mmap
-	// unconditionally (unlike Tree.Get, they have no zero-copy gate of their
-	// own), so clone them here under the same zeroCopy flag.
+	// PersistedNode.Key()/Value() alias the mmap unconditionally, unlike Tree.Get, so clone under zeroCopy.
 	nodeKey, nodeValue := node.Key(), node.Value()
 	if !t.zeroCopy {
 		nodeKey = bytes.Clone(nodeKey)

--- a/memiavl/proof_test.go
+++ b/memiavl/proof_test.go
@@ -23,31 +23,39 @@ func TestProofsEmptyTree(t *testing.T) {
 func TestProofOutlivesSnapshotWhenZeroCopyDisabled(t *testing.T) {
 	tmpDir := t.TempDir()
 	tree := New(0)
-	tree.ApplyChangeSet(ChangeSets[0])
-	_, _, err := tree.SaveVersion(true)
-	require.NoError(t, err)
+	for _, changes := range ChangeSets[:6] {
+		tree.ApplyChangeSet(changes)
+		_, _, err := tree.SaveVersion(true)
+		require.NoError(t, err)
+	}
 	require.NoError(t, tree.WriteSnapshot(tmpDir))
 
 	snapshot, err := OpenSnapshot(tmpDir)
 	require.NoError(t, err)
 	ptree := NewFromSnapshot(snapshot, false, 0)
 
-	existKey := []byte("hello")
+	existKey := []byte("hello1")
 	exist, err := ptree.GetMembershipProof(existKey)
 	require.NoError(t, err)
-	nonExist, err := ptree.GetNonMembershipProof([]byte("hello1"))
+	require.NotEmpty(t, exist.GetExist().Path, "test key must have a non-trivial inner path")
+
+	nonExist, err := ptree.GetNonMembershipProof([]byte("hello12"))
 	require.NoError(t, err)
 	left := nonExist.GetNonexist().Left
+	right := nonExist.GetNonexist().Right
 	require.NotNil(t, left)
+	require.NotNil(t, right)
 
 	require.NoError(t, ptree.Close())
 
 	// turn a fault from touching the unmapped snapshot into a failing panic instead of a crash
 	defer debug.SetPanicOnFault(debug.SetPanicOnFault(true))
 	require.Equal(t, existKey, exist.GetExist().Key)
-	require.Equal(t, []byte("world"), exist.GetExist().Value)
+	require.Equal(t, []byte("world1"), exist.GetExist().Value)
 	require.Equal(t, existKey, left.Key)
-	require.Equal(t, []byte("world"), left.Value)
+	require.Equal(t, []byte("world1"), left.Value)
+	require.Equal(t, []byte("hello2"), right.Key)
+	require.Equal(t, []byte("world1"), right.Value)
 }
 
 func TestProofs(t *testing.T) {

--- a/memiavl/proof_test.go
+++ b/memiavl/proof_test.go
@@ -1,6 +1,7 @@
 package memiavl
 
 import (
+	"runtime/debug"
 	"strconv"
 	"testing"
 
@@ -17,6 +18,37 @@ func TestProofsEmptyTree(t *testing.T) {
 	nonExistProof, err := tree.GetNonMembershipProof([]byte("hello"))
 	require.Error(t, err)
 	require.Nil(t, nonExistProof)
+}
+
+func TestProofOutlivesSnapshotWhenZeroCopyDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	tree := New(0)
+	tree.ApplyChangeSet(ChangeSets[0])
+	_, _, err := tree.SaveVersion(true)
+	require.NoError(t, err)
+	require.NoError(t, tree.WriteSnapshot(tmpDir))
+
+	snapshot, err := OpenSnapshot(tmpDir)
+	require.NoError(t, err)
+	ptree := NewFromSnapshot(snapshot, false, 0)
+
+	existKey := []byte("hello")
+	exist, err := ptree.GetMembershipProof(existKey)
+	require.NoError(t, err)
+	nonExist, err := ptree.GetNonMembershipProof([]byte("hello1"))
+	require.NoError(t, err)
+	left := nonExist.GetNonexist().Left
+	require.NotNil(t, left)
+
+	require.NoError(t, ptree.Close())
+
+	// a proof still aliasing the unmapped snapshot faults instead of comparing,
+	// so turn the fault into a recoverable panic that fails the test
+	defer debug.SetPanicOnFault(debug.SetPanicOnFault(true))
+	require.Equal(t, existKey, exist.GetExist().Key)
+	require.Equal(t, []byte("world"), exist.GetExist().Value)
+	require.Equal(t, existKey, left.Key)
+	require.Equal(t, []byte("world"), left.Value)
 }
 
 func TestProofs(t *testing.T) {

--- a/memiavl/proof_test.go
+++ b/memiavl/proof_test.go
@@ -42,8 +42,7 @@ func TestProofOutlivesSnapshotWhenZeroCopyDisabled(t *testing.T) {
 
 	require.NoError(t, ptree.Close())
 
-	// a proof still aliasing the unmapped snapshot faults instead of comparing,
-	// so turn the fault into a recoverable panic that fails the test
+	// turn a fault from touching the unmapped snapshot into a failing panic instead of a crash
 	defer debug.SetPanicOnFault(debug.SetPanicOnFault(true))
 	require.Equal(t, existKey, exist.GetExist().Key)
 	require.Equal(t, []byte("world"), exist.GetExist().Value)

--- a/memiavl/tree.go
+++ b/memiavl/tree.go
@@ -353,12 +353,10 @@ func (t *Tree) Get(key []byte) []byte {
 
 	if t.cache != nil {
 		cacheKey := key
-		cacheValue := value
 		if !t.zeroCopy {
 			cacheKey = bytes.Clone(key)
-			cacheValue = bytes.Clone(cacheValue)
 		}
-		t.cache.Add(&cacheNode{cacheKey, cacheValue})
+		t.cache.Add(&cacheNode{cacheKey, value})
 	}
 	return value
 }

--- a/store/config/toml.go
+++ b/store/config/toml.go
@@ -14,6 +14,8 @@ enable = {{ .MemIAVL.Enable }}
 # ZeroCopy defines if the memiavl should return slices pointing to mmap-ed buffers directly (zero-copy),
 # the zero-copied slices must not be retained beyond current block's execution.
 # the sdk address cache will be disabled if zero-copy is enabled.
+# only affects latest-height reads; historical-height queries always copy, since their snapshot can be
+# unmapped by the historical store cache while a response is still in flight.
 zero-copy = {{ .MemIAVL.ZeroCopy }}
 
 # AsyncCommitBuffer defines the size of asynchronous commit queue, this greatly improve block catching-up

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -171,6 +171,10 @@ func (c *historicalDBCache) close() error {
 func loadAtVersion(dir string, opts memiavl.Options, chainId string, version int64) (*memiavl.DB, error) {
 	opts.TargetVersion = uint32(version)
 	opts.ReadOnly = true
+	// historicalDBCache's LRU can close this DB (unmapping its snapshot) while
+	// a borrower still holds a *ResponseQuery* referencing it, so results must
+	// be copied out of the mmap rather than aliasing it.
+	opts.ZeroCopy = false
 	db, err := memiavl.Load(dir, opts, chainId)
 	if err != nil {
 		return nil, err

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -171,9 +171,7 @@ func (c *historicalDBCache) close() error {
 func loadAtVersion(dir string, opts memiavl.Options, chainId string, version int64) (*memiavl.DB, error) {
 	opts.TargetVersion = uint32(version)
 	opts.ReadOnly = true
-	// historicalDBCache's LRU can close this DB (unmapping its snapshot) while
-	// a borrower still holds a *ResponseQuery* referencing it, so results must
-	// be copied out of the mmap rather than aliasing it.
+	// historicalDBCache's LRU can close this DB, unmapping its snapshot, while a caller still holds a ResponseQuery referencing it.
 	opts.ZeroCopy = false
 	db, err := memiavl.Load(dir, opts, chainId)
 	if err != nil {

--- a/store/rootmulti/store_bench_test.go
+++ b/store/rootmulti/store_bench_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	log "cosmossdk.io/log/v2"
-	"github.com/cosmos/cosmos-sdk/store/v2/types"
 	"github.com/crypto-org-chain/cronos-store/memiavl"
+
+	log "cosmossdk.io/log/v2"
+
+	"github.com/cosmos/cosmos-sdk/store/v2/types"
 )
 
 const benchNumKeys = 1000
@@ -105,7 +107,7 @@ func BenchmarkHistoricalQuery(b *testing.B) {
 	})
 }
 
-// the cold cost the LRU amortises, for scale against BenchmarkHistoricalQuery
+// the cold cost the LRU amortizes, for scale against BenchmarkHistoricalQuery
 func BenchmarkHistoricalLoad(b *testing.B) {
 	store, target := setupHistoricalBenchStore(b)
 

--- a/store/rootmulti/store_bench_test.go
+++ b/store/rootmulti/store_bench_test.go
@@ -1,0 +1,123 @@
+package rootmulti
+
+import (
+	"fmt"
+	"testing"
+
+	log "cosmossdk.io/log/v2"
+	"github.com/cosmos/cosmos-sdk/store/v2/types"
+	"github.com/crypto-org-chain/cronos-store/memiavl"
+)
+
+const benchNumKeys = 1000
+
+// returns a store whose `target` version has an on-disk snapshot and is no
+// longer the latest height, so queries at it go through historicalDBCache
+func setupHistoricalBenchStore(b *testing.B) (*Store, int64) {
+	b.Helper()
+
+	store := NewStore(b.TempDir(), log.NewNopLogger(), false, false, TestAppChainID)
+	store.SetMemIAVLOptions(memiavl.Options{
+		// larger than the versions committed here, so the background rewrite
+		// never races the synchronous RewriteSnapshot below
+		SnapshotInterval:   10000,
+		SnapshotKeepRecent: 100,
+		ZeroCopy:           true, // operator opt-in; loadAtVersion must override it
+		CacheSize:          0,
+	})
+
+	key := types.NewKVStoreKey(testStoreName)
+	store.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	if err := store.LoadLatestVersion(); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { store.Close() })
+
+	kvStore := store.GetKVStore(key)
+	for i := 0; i < benchNumKeys; i++ {
+		kvStore.Set([]byte(fmt.Sprintf("pfx/%06d", i)), []byte(fmt.Sprintf("value-%06d-padding-padding-padding", i)))
+	}
+	target := store.Commit().Version
+	if err := store.db.WaitAsyncCommit(); err != nil {
+		b.Fatal(err)
+	}
+	if err := store.db.RewriteSnapshot(); err != nil {
+		b.Fatal(err)
+	}
+
+	store.GetKVStore(key).Set([]byte("zzz"), []byte("v"))
+	store.Commit()
+	if err := store.db.WaitAsyncCommit(); err != nil {
+		b.Fatal(err)
+	}
+	return store, target
+}
+
+// measures the copy overhead loadAtVersion's forced ZeroCopy=false adds, with
+// the DB already in the LRU so the load cost is outside the measured path
+func BenchmarkHistoricalQuery(b *testing.B) {
+	store, target := setupHistoricalBenchStore(b)
+	path := "/" + testStoreName + "/key"
+	subspacePath := "/" + testStoreName + "/subspace"
+	pointKey := []byte(fmt.Sprintf("pfx/%06d", benchNumKeys/2))
+
+	if _, err := store.Query(&types.RequestQuery{Path: path, Data: pointKey, Height: target}); err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("point", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			res, err := store.Query(&types.RequestQuery{Path: path, Data: pointKey, Height: target})
+			if err != nil {
+				b.Fatal(err)
+			}
+			if res.Value == nil {
+				b.Fatal("missing value")
+			}
+		}
+	})
+
+	b.Run("point_prove", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			res, err := store.Query(&types.RequestQuery{Path: path, Data: pointKey, Height: target, Prove: true})
+			if err != nil {
+				b.Fatal(err)
+			}
+			if res.ProofOps == nil {
+				b.Fatal("missing proof")
+			}
+		}
+	})
+
+	b.Run("subspace", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			res, err := store.Query(&types.RequestQuery{Path: subspacePath, Data: []byte("pfx/"), Height: target})
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(res.Value) == 0 {
+				b.Fatal("empty subspace result")
+			}
+		}
+	})
+}
+
+// the cold cost the LRU amortises, for scale against BenchmarkHistoricalQuery
+func BenchmarkHistoricalLoad(b *testing.B) {
+	store, target := setupHistoricalBenchStore(b)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		db, err := loadAtVersion(store.dir, store.opts, TestAppChainID, target)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -2,10 +2,12 @@ package rootmulti
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	protoio "github.com/cosmos/gogoproto/io"
 	"github.com/crypto-org-chain/cronos-store/memiavl"
@@ -521,6 +523,137 @@ func TestQueryHistoricalHeightAllowsRenamedStore(t *testing.T) {
 	res, err := store.Query(&types.RequestQuery{Path: "/old/key", Data: []byte("k"), Height: 1})
 	require.NoError(t, err)
 	require.Equal(t, []byte("v"), res.Value)
+}
+
+// TestLoadAtVersionDisablesZeroCopy verifies that loadAtVersion forces
+// ZeroCopy off for historical loads even when the operator's app.toml opts
+// (memiavl.zero-copy=true) request it. historicalDBCache can evict and close
+// a historical DB while its results are still in flight, so those results
+// must be safe to read after close rather than aliasing the closed mmap.
+func TestLoadAtVersionDisablesZeroCopy(t *testing.T) {
+	dir := t.TempDir()
+	db, err := memiavl.Load(dir, memiavl.Options{
+		CreateIfMissing:   true,
+		InitialStores:     []string{testStoreName},
+		AsyncCommitBuffer: -1,
+	}, TestAppChainID)
+	require.NoError(t, err)
+	require.NoError(t, db.ApplyChangeSet(testStoreName, memiavl.ChangeSet{Pairs: []*memiavl.KVPair{{Key: []byte("k"), Value: bytes.Repeat([]byte("v"), 64)}}}))
+	_, err = db.Commit()
+	require.NoError(t, err)
+	require.NoError(t, db.WaitAsyncCommit())
+	// Write a real on-disk snapshot for version 1 synchronously, so
+	// loadAtVersion below loads a genuine mmap-backed PersistedNode tree
+	// instead of falling back to WAL replay (which builds an in-memory tree
+	// that isn't zero-copy in the first place, and so wouldn't exercise the
+	// code path this test targets).
+	require.NoError(t, db.RewriteSnapshot())
+	require.NoError(t, db.Close())
+
+	// CacheSize: 0 disables the tree's value cache so repeated Get calls go
+	// through the real get path instead of returning a cached hit.
+	opts := memiavl.Options{ZeroCopy: true, CacheSize: 0}
+	historical, err := loadAtVersion(dir, opts, TestAppChainID, 1)
+	require.NoError(t, err)
+	defer historical.Close()
+
+	tree := historical.TreeByName(testStoreName)
+	require.NotNil(t, tree)
+
+	want := bytes.Repeat([]byte("v"), 64)
+	first := tree.Get([]byte("k"))
+	second := tree.Get([]byte("k"))
+	require.Equal(t, want, first)
+	// If zero-copy were still enabled, both calls would alias the same mmap
+	// address; a disabled zero-copy path clones on every call, so the two
+	// results never share a backing array. Compare as uintptr, not *byte:
+	// reflect.DeepEqual (which require.NotEqual uses) follows pointers and
+	// compares pointee values, so two distinct addresses holding the same
+	// byte content would misleadingly compare as "equal".
+	firstAddr := uintptr(unsafe.Pointer(unsafe.SliceData(first)))
+	secondAddr := uintptr(unsafe.Pointer(unsafe.SliceData(second)))
+	require.NotEqual(t, firstAddr, secondAddr,
+		"loadAtVersion must force ZeroCopy off so historical reads are cloned, not aliased to the mmap")
+}
+
+// TestHistoricalQueryResultSurvivesCacheEviction reproduces the use-after-free
+// this package guards against: a Store.Query result for a historical height
+// must remain valid after its underlying historicalDBCache entry is evicted
+// and closed by later, unrelated historical queries.
+func TestHistoricalQueryResultSurvivesCacheEviction(t *testing.T) {
+	numVersions := defaultHistoricalDBCacheSize + 1
+	dir := t.TempDir()
+	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
+	store.SetMemIAVLOptions(memiavl.Options{
+		// SnapshotInterval is set larger than numVersions so the automatic
+		// background rewrite never fires; each version's snapshot is instead
+		// written synchronously below via RewriteSnapshot, so every borrow
+		// below loads a real mmap-backed PersistedNode tree rather than
+		// falling back to WAL replay.
+		SnapshotInterval:   uint32(numVersions + 10),
+		SnapshotKeepRecent: uint32(numVersions + 1),
+		ZeroCopy:           true, // simulates operator's memiavl.zero-copy=true
+		CacheSize:          0,
+	})
+
+	key := types.NewKVStoreKey(testStoreName)
+	store.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	require.NoError(t, store.LoadLatestVersion())
+	t.Cleanup(func() { store.Close() })
+
+	values := make([][]byte, numVersions)
+	versions := make([]int64, numVersions)
+	for i := 0; i < numVersions; i++ {
+		values[i] = []byte(fmt.Sprintf("value-%d", i))
+		kvStore := store.GetKVStore(key)
+		kvStore.Set([]byte("k"), values[i])
+		cid := store.Commit()
+		versions[i] = cid.Version
+		require.NoError(t, store.db.WaitAsyncCommit())
+		require.NoError(t, store.db.RewriteSnapshot())
+	}
+	// One more commit so none of versions[0..numVersions-1] is the store's
+	// current height; otherwise Store.Query would serve the last of them
+	// straight from rs.lastCommitInfo, bypassing historicalDBCache entirely.
+	finalCid := store.Commit()
+	require.Greater(t, finalCid.Version, versions[numVersions-1])
+	require.NoError(t, store.db.WaitAsyncCommit())
+
+	path := "/" + testStoreName + "/key"
+
+	// Query the earliest historical version first; its cache entry is the one
+	// that will be evicted once defaultHistoricalDBCacheSize more distinct
+	// versions have been queried after it.
+	res0, err := store.Query(&types.RequestQuery{Path: path, Data: []byte("k"), Height: versions[0], Prove: true})
+	require.NoError(t, err)
+	require.Equal(t, values[0], res0.Value)
+	require.NotNil(t, res0.ProofOps)
+	require.NotEmpty(t, res0.ProofOps.Ops)
+
+	// Query defaultHistoricalDBCacheSize more distinct versions. Since each
+	// call's own borrow is released before Query returns, the last of these
+	// evicts version[0]'s entry with refs==0, closing it synchronously.
+	for i := 1; i <= defaultHistoricalDBCacheSize; i++ {
+		_, err := store.Query(&types.RequestQuery{Path: path, Data: []byte("k"), Height: versions[i], Prove: true})
+		require.NoError(t, err)
+	}
+
+	// Confirm version[0] actually fell out of the LRU window, so the
+	// assertions below exercise a result whose backing DB has been closed.
+	store.historicalDBCache.mu.Lock()
+	evicted := true
+	for _, e := range store.historicalDBCache.entries {
+		if e.version == versions[0] {
+			evicted = false
+		}
+	}
+	store.historicalDBCache.mu.Unlock()
+	require.True(t, evicted, "version[0]'s entry should have been evicted")
+
+	// res0 was returned before the eviction above; its Value and ProofOps
+	// must not alias the now-closed snapshot's mmap.
+	require.Equal(t, values[0], res0.Value)
+	require.NotEmpty(t, res0.ProofOps.Ops)
 }
 
 func TestCacheMultiStoreWithVersionHistoricalHeightSkipsDeletedStore(t *testing.T) {

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -619,6 +620,8 @@ func TestHistoricalQueryResultSurvivesCacheEviction(t *testing.T) {
 	store.historicalDBCache.mu.Unlock()
 	require.True(t, evicted, "version[0]'s entry should have been evicted")
 
+	// a result still aliasing the unmapped snapshot faults; make that a failing panic instead of killing the test binary
+	defer debug.SetPanicOnFault(debug.SetPanicOnFault(true))
 	require.Equal(t, values[0], res0.Value)
 	require.NotEmpty(t, res0.ProofOps.Ops)
 }

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -525,11 +525,6 @@ func TestQueryHistoricalHeightAllowsRenamedStore(t *testing.T) {
 	require.Equal(t, []byte("v"), res.Value)
 }
 
-// TestLoadAtVersionDisablesZeroCopy verifies that loadAtVersion forces
-// ZeroCopy off for historical loads even when the operator's app.toml opts
-// (memiavl.zero-copy=true) request it. historicalDBCache can evict and close
-// a historical DB while its results are still in flight, so those results
-// must be safe to read after close rather than aliasing the closed mmap.
 func TestLoadAtVersionDisablesZeroCopy(t *testing.T) {
 	dir := t.TempDir()
 	db, err := memiavl.Load(dir, memiavl.Options{
@@ -542,16 +537,11 @@ func TestLoadAtVersionDisablesZeroCopy(t *testing.T) {
 	_, err = db.Commit()
 	require.NoError(t, err)
 	require.NoError(t, db.WaitAsyncCommit())
-	// Write a real on-disk snapshot for version 1 synchronously, so
-	// loadAtVersion below loads a genuine mmap-backed PersistedNode tree
-	// instead of falling back to WAL replay (which builds an in-memory tree
-	// that isn't zero-copy in the first place, and so wouldn't exercise the
-	// code path this test targets).
+	// force a real on-disk snapshot so loadAtVersion loads an mmap-backed PersistedNode tree, not a WAL-replayed one
 	require.NoError(t, db.RewriteSnapshot())
 	require.NoError(t, db.Close())
 
-	// CacheSize: 0 disables the tree's value cache so repeated Get calls go
-	// through the real get path instead of returning a cached hit.
+	// CacheSize: 0 forces every Get through the real path instead of a cache hit
 	opts := memiavl.Options{ZeroCopy: true, CacheSize: 0}
 	historical, err := loadAtVersion(dir, opts, TestAppChainID, 1)
 	require.NoError(t, err)
@@ -564,32 +554,19 @@ func TestLoadAtVersionDisablesZeroCopy(t *testing.T) {
 	first := tree.Get([]byte("k"))
 	second := tree.Get([]byte("k"))
 	require.Equal(t, want, first)
-	// If zero-copy were still enabled, both calls would alias the same mmap
-	// address; a disabled zero-copy path clones on every call, so the two
-	// results never share a backing array. Compare as uintptr, not *byte:
-	// reflect.DeepEqual (which require.NotEqual uses) follows pointers and
-	// compares pointee values, so two distinct addresses holding the same
-	// byte content would misleadingly compare as "equal".
+	// compare backing addresses, not require.NotEqual (which follows pointers and would treat equal content as equal)
 	firstAddr := uintptr(unsafe.Pointer(unsafe.SliceData(first)))
 	secondAddr := uintptr(unsafe.Pointer(unsafe.SliceData(second)))
 	require.NotEqual(t, firstAddr, secondAddr,
 		"loadAtVersion must force ZeroCopy off so historical reads are cloned, not aliased to the mmap")
 }
 
-// TestHistoricalQueryResultSurvivesCacheEviction reproduces the use-after-free
-// this package guards against: a Store.Query result for a historical height
-// must remain valid after its underlying historicalDBCache entry is evicted
-// and closed by later, unrelated historical queries.
 func TestHistoricalQueryResultSurvivesCacheEviction(t *testing.T) {
 	numVersions := defaultHistoricalDBCacheSize + 1
 	dir := t.TempDir()
 	store := NewStore(dir, log.NewNopLogger(), false, false, TestAppChainID)
 	store.SetMemIAVLOptions(memiavl.Options{
-		// SnapshotInterval is set larger than numVersions so the automatic
-		// background rewrite never fires; each version's snapshot is instead
-		// written synchronously below via RewriteSnapshot, so every borrow
-		// below loads a real mmap-backed PersistedNode tree rather than
-		// falling back to WAL replay.
+		// larger than numVersions so the background rewrite never fires; snapshots are written synchronously below instead
 		SnapshotInterval:   uint32(numVersions + 10),
 		SnapshotKeepRecent: uint32(numVersions + 1),
 		ZeroCopy:           true, // simulates operator's memiavl.zero-copy=true
@@ -612,34 +589,26 @@ func TestHistoricalQueryResultSurvivesCacheEviction(t *testing.T) {
 		require.NoError(t, store.db.WaitAsyncCommit())
 		require.NoError(t, store.db.RewriteSnapshot())
 	}
-	// One more commit so none of versions[0..numVersions-1] is the store's
-	// current height; otherwise Store.Query would serve the last of them
-	// straight from rs.lastCommitInfo, bypassing historicalDBCache entirely.
+	// one more commit so no queried version is current, else Query would bypass historicalDBCache via rs.lastCommitInfo
 	finalCid := store.Commit()
 	require.Greater(t, finalCid.Version, versions[numVersions-1])
 	require.NoError(t, store.db.WaitAsyncCommit())
 
 	path := "/" + testStoreName + "/key"
 
-	// Query the earliest historical version first; its cache entry is the one
-	// that will be evicted once defaultHistoricalDBCacheSize more distinct
-	// versions have been queried after it.
+	// this entry gets evicted once defaultHistoricalDBCacheSize more distinct versions are queried after it
 	res0, err := store.Query(&types.RequestQuery{Path: path, Data: []byte("k"), Height: versions[0], Prove: true})
 	require.NoError(t, err)
 	require.Equal(t, values[0], res0.Value)
 	require.NotNil(t, res0.ProofOps)
 	require.NotEmpty(t, res0.ProofOps.Ops)
 
-	// Query defaultHistoricalDBCacheSize more distinct versions. Since each
-	// call's own borrow is released before Query returns, the last of these
-	// evicts version[0]'s entry with refs==0, closing it synchronously.
+	// the last of these evicts version[0]'s entry with refs==0, closing it synchronously
 	for i := 1; i <= defaultHistoricalDBCacheSize; i++ {
 		_, err := store.Query(&types.RequestQuery{Path: path, Data: []byte("k"), Height: versions[i], Prove: true})
 		require.NoError(t, err)
 	}
 
-	// Confirm version[0] actually fell out of the LRU window, so the
-	// assertions below exercise a result whose backing DB has been closed.
 	store.historicalDBCache.mu.Lock()
 	evicted := true
 	for _, e := range store.historicalDBCache.entries {
@@ -650,8 +619,6 @@ func TestHistoricalQueryResultSurvivesCacheEviction(t *testing.T) {
 	store.historicalDBCache.mu.Unlock()
 	require.True(t, evicted, "version[0]'s entry should have been evicted")
 
-	// res0 was returned before the eviction above; its Value and ProofOps
-	// must not alias the now-closed snapshot's mmap.
 	require.Equal(t, values[0], res0.Value)
 	require.NotEmpty(t, res0.ProofOps.Ops)
 }


### PR DESCRIPTION
### What

`loadAtVersion` in `store/rootmulti` now forces `ZeroCopy = false` on the historical memiavl DB it opens, so historical query results are cloned instead of aliasing the snapshot mmap. Also clones the leaf key/value in `memiavl/createExistenceProof` under the tree's own `zeroCopy` flag, and memoizes `Iterator.Key()/Value()` clones per position so the added copying is paid once per element instead of once per call.

### Issue

`loadAtVersion` inherited `ZeroCopy` from the operator's `rs.opts`. With zero-copy on, `Store.Query` returned a `ResponseQuery` whose `Value` pointed into the snapshot mmap. The historical DB cache is an LRU of size 4: once the borrower releases the entry and the LRU evicts it, `db.Close()` unmaps the snapshot — and the already-returned response is left pointing at unmapped memory. Reading it faults (SIGSEGV) or returns garbage.

The refcounting itself is fine: `close` only fires at `refs == 0 && evicted`, and `Query` holds the borrow across its whole body. The defect is purely results escaping past the release.

Separately, `PersistedNode.Key()/Value()` alias the mmap unconditionally — unlike `Tree.Get`/`GetByIndex`/`Iterator`, they have no zero-copy gate of their own. So `createExistenceProof` handed back mmap-backed slices even on a tree built with `zeroCopy = false`, violating that tree's contract.

**Scope of the live bug.** `ZeroCopy` defaults to false, so only operators who set `memiavl.zero-copy = true` were exposed. Within `Store.Query` the one field that genuinely escapes is `res.Value` on the `/key` path (a bare `tree.Get`). `/subspace` and the proof ops are already safe, because `pairs.Marshal()` and `CommitmentOp.ProofOp()` copy into fresh buffers while the borrow is still held.

**Tradeoff.** Historical queries now allocate a copy per value. Measured on darwin/arm64 (M4 Max), medians of `-count 5`, warm LRU, 1000 keys of 34-byte values, comparing against the same benchmarks with the `ZeroCopy = false` line removed:

| Query | Before | After | Delta |
| --- | --- | --- | --- |
| `/key` | 125 ns, 212 B, 4 allocs | 134 ns, 260 B, 5 allocs | +7% |
| `/key` with `Prove` | 2693 ns, 6320 B, 99 allocs | 2629 ns, 6432 B, 102 allocs | within noise, +112 B |
| `/subspace`, 1000 keys | 83.8 µs, 212 KB, 2022 allocs | 107.2 µs, 276 KB, 4022 allocs | +28% |
| cold `loadAtVersion` | 260 µs | 260 µs | unchanged |

For scale: one cold historical DB load is ~260 µs, so the +9 ns on a point query and the +23 µs on a full 1000-key scan are both small next to the load the LRU exists to amortise. Copy overhead on a scan is +23 ns and +64 B per element — exactly one key clone plus one value clone. Live (non-historical) queries are untouched; they still honor the operator's setting.

### Solution

- `loadAtVersion` sets `opts.ZeroCopy = false` unconditionally, next to the existing `ReadOnly = true`.
- `createExistenceProof` clones `node.Key()`/`node.Value()` when `!t.zeroCopy`. `convertInnerOps` needed no change — it builds prefix/suffix with `append` into fresh slices, so aliased `Hash()` bytes are copied in transit, and `nonexist.Key` is the caller's own key.
- `Iterator` caches its key/value clone per position and resets it in `Next()`, rather than cloning on every `Key()`/`Value()` call. Callers must treat the result as read-only (`CONTRACT: key readonly []byte` on `dbm.Iterator`), and resetting on `Next` means a retained slice is never overwritten. On the repeated-access pattern the cachekv merge iterator produces (3x `Key()` + 1x `Value()` per position), this is 153 → 103 allocs/op, 1952 → 1600 B/op, ~30% faster. It does not change `/subspace`: `KVStorePrefixIterator` is a bare `kvs.Iterator`, so it already called each accessor once per element. The win is on the cachekv-wrapped execution path, where zero-copy is off by default.
- `app.toml` template notes that `zero-copy` no longer applies to historical queries, so operators do not expect it from archive reads.
- `createExistenceProof` now returns immediately on a `pathToLeaf` error, instead of falling through to build an existence proof that would be discarded anyway.
- `Tree.Get` no longer clones the cached value a second time; `GetWithIndex` already clones it under `!zeroCopy`.

Note the first two changes are independent. The `rootmulti` path is in fact already saved from the proof aliasing by `CommitmentOp.ProofOp()`, which protobuf-marshals the proof into a fresh buffer while the borrow is still held. The `proof.go` change fixes the memiavl API contract for any other caller of `GetMembershipProof`.

### Test

Four new tests, each verified to fail without its fix:

- `TestLoadAtVersionDisablesZeroCopy` (`store/rootmulti`) — commits two versions, reads the same key from two separately-loaded historical DBs, and asserts the backing pointers differ. Compares `uintptr(unsafe.Pointer(unsafe.SliceData(...)))` rather than the slices, because `require.NotEqual` uses `reflect.DeepEqual`, which follows pointers and would compare pointee content instead of addresses.
- `TestHistoricalQueryResultSurvivesCacheEviction` (`store/rootmulti`) — sets `ZeroCopy: true` to simulate the operator setting, queries an old version with `Prove: true`, then queries `defaultHistoricalDBCacheSize` more versions to force eviction. Asserts eviction actually happened by locking `historicalDBCache.mu` and scanning `entries`, then re-reads the response value and proof ops. Without the fix this faults rather than failing, so the final reads are guarded with `debug.SetPanicOnFault` — otherwise a regression takes down the whole package's test binary with a SIGSEGV and is easy to misattribute.
- `TestProofOutlivesSnapshotWhenZeroCopyDisabled` (`memiavl`) — builds a multi-version, multi-leaf snapshot-backed tree with `zeroCopy = false` so the membership proof has a real inner-node path and the non-membership proof has both `Left`/`Right` branches, takes both proofs, closes the tree, then reads the proof key/value. Mirrors the existing `TestZeroCopy` idiom (`debug.SetPanicOnFault`).
- `TestIteratorZeroCopyDisabledClonesPerPosition` (`memiavl`) — asserts repeated `Key()`/`Value()` calls at one position return the same backing array, that advancing hands out a fresh one so a retained slice is not overwritten, and that retained pairs still read correctly after the snapshot is unmapped.

Benchmarks added so the numbers above are reproducible: `BenchmarkHistoricalQuery` (point, proof, subspace) and `BenchmarkHistoricalLoad` in `store/rootmulti`, `BenchmarkIteratorRepeatedKeyAccess` in `memiavl`.


